### PR TITLE
chore: migrate CI actions to Node 24 + CodeQL v4

### DIFF
--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -27,13 +27,13 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary
- upgrade actions/checkout from v4 to v5
- upgrade github/codeql-action/* from v3 to v4
- keep workflow behavior unchanged
