### PR TITLE
ci: upgrade CodeQL Action to v4

### DIFF
--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -27,13 +27,13 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary
- upgrade github/codeql-action init/autobuild/analyze from v3 to v4
- keeps workflow behavior unchanged, only version bump for deprecation compliance