### PR TITLE
[codex] Run Scorecard after security workflow changes

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,5 +1,11 @@
 name: OpenSSF Scorecard
 on:
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/**"
+      - ".github/dependabot.yml"
+      - "SECURITY.md"
   schedule:
     - cron: "37 8 * * 1"
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Add a filtered `push` trigger on `main` to the OpenSSF Scorecard workflow.
- Keep the existing weekly schedule and manual dispatch.
- Limit automatic runs to workflow/security configuration paths so normal application commits do not run Scorecard unnecessarily.

## Validation
- Parsed `scorecard.yml` locally.
- `git diff --check` passed.