### PR TITLE
fix(security): reconcile GitPython dependency alerts

### DIFF
--- a/socketsecurity-requirements.in
+++ b/socketsecurity-requirements.in
@@ -1,5 +1,5 @@
 # Direct dependencies for the Socket Security workflow.
 # Regenerate socketsecurity-requirements.txt with hashes after every update.
 socketsecurity==2.5.0
-# Explicit security floor for GHSA-rwj8-pgh3-r573.
-gitpython>=3.1.54
+# Exact current release; Dependabot updates this source and the hash lock together.
+gitpython==3.1.54


### PR DESCRIPTION
## O que muda

- fixa o requisito direto do workflow Socket Security em `gitpython==3.1.54`;
- mantém o lock com hashes byte a byte inalterado, pois ele já resolve exatamente `GitPython 3.1.54`;
- torna inequívoca para o grafo de dependências a versão segura efetivamente instalada.

## Causa raiz

Os alertas Dependabot #27–#30 ainda apontam para `GitPython 3.1.50` em `socketsecurity-requirements.txt`, embora `main` e o lock atual já contenham `3.1.54`. A entrada permissiva `gitpython>=3.1.54` no arquivo-fonte permitia esse desencontro de representação. Esses alertas foram historicamente reais e não serão descartados como falso positivo.

## Validação local fresca

- `npm ci` (0 vulnerabilidades npm)
- `npm test` (8/8)
- `npm run lint`
- `npm run biome`
- `npm run build`
- `npm run format:public:check`
- `python -m pip install --dry-run --ignore-installed --require-hashes -r socketsecurity-requirements.txt`
- `git diff --check`

Nenhum banco de dados, segredo, release, tag ou dado de produção é alterado.