### PR TITLE
ci: update Dependabot controller pin

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -34,7 +34,7 @@ jobs:
             api.github.com:443
 
       - name: Process one guarded queue mutation
-        uses: LCV-Ideas-Software/.github/dependabot-automerge@06078610da5edd1c6d020db205c69d3cd580fcf9
+        uses: LCV-Ideas-Software/.github/dependabot-automerge@d8f67ca034edb6173ce9baaff41ccb320ef4bf2d
         with:
           github_token: ${{ github.token }}
           automation_token: ${{ secrets.LCV_AUTOMATION_TOKEN }}


### PR DESCRIPTION
Atualiza somente o pin imutável do controlador central de Dependabot para `d8f67ca034edb6173ce9baaff41ccb320ef4bf2d`, que inclui o suporte estrito a `socketsecurity-requirements.in` e `socketsecurity-requirements.txt`.

Mantém `permissions: write-all` inalterado.

Validação local:
- `git diff --check`
- parsing com PyYAML
- Prettier
- actionlint sem achados além da lacuna de schema preexistente para `concurrency.queue`
- zizmor 1.28.0: nenhum achado não ignorado