### PR TITLE
chore(ci): repin Dependabot controller

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -34,7 +34,7 @@ jobs:
             api.github.com:443
 
       - name: Process one guarded queue mutation
-        uses: LCV-Ideas-Software/.github/dependabot-automerge@3f62b39a76f767d09a5482b8e380746883be3b94
+        uses: LCV-Ideas-Software/.github/dependabot-automerge@86383cce42ac86077f87ad80ab48d4308fdd1ab6
         with:
           github_token: ${{ github.token }}
           automation_token: ${{ secrets.LCV_AUTOMATION_TOKEN }}


### PR DESCRIPTION
## Objetivo

Atualiza o pin imutável do controller compartilhado do Dependabot para `86383cce42ac86077f87ad80ab48d4308fdd1ab6`.

Esse SHA inclui a correção validada para respostas canônicas do Dependabot criadas no mesmo segundo da solicitação, preservando ordenação estrita por IDs inteiros seguros e comportamento fail-closed.

## Validação

- diff restrito a uma substituição de SHA no wrapper
- `git diff --check`
- `actionlint` sem achados além da defasagem conhecida para o `queue: max` oficial do GitHub
- `zizmor` sem achados