### PR TITLE
fix(ci): tolerate release read-after-write lag

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -631,6 +631,14 @@ jobs:
               jq -sc 'if length == 0 then [] else add end'
           }
 
+          published_release_snapshot() {
+            local encoded_tag
+            encoded_tag="$(jq -rn --arg value "$RELEASE_TAG" '$value | @uri')"
+            gh api --method GET \
+              "repos/${GITHUB_REPOSITORY}/releases/tags/${encoded_tag}" |
+              jq -c '[.]'
+          }
+
           resolve_commitish() {
             local commitish="$1"
             local encoded_commitish resolved_sha
@@ -762,13 +770,41 @@ jobs:
           esac
 
           assert_tag_is_target "$RELEASE_TAG"
-          releases="$(release_snapshot)"
-          selected_releases="$(jq -c --arg tag "$RELEASE_TAG" '[.[] | select(.tag_name == $tag)]' <<<"$releases")"
-          final_state="$(release_state "$selected_releases")"
-          if [ "$final_state" != published ]; then
-            echo "::error::Release ${RELEASE_TAG} did not converge to a published normal release." >&2
-            exit 1
-          fi
+          # A successful release mutation can precede visibility through the
+          # read endpoint. Retry only GET visibility; release_state still fails
+          # immediately for an invalid target, prerelease, or uploaded asset.
+          final_state=unavailable
+          lookup_error=
+          for retry_delay in 1 2 4 8 15 0; do
+            if selected_releases="$(published_release_snapshot 2>&1)"; then
+              final_state="$(release_state "$selected_releases")"
+              case "$final_state" in
+                published)
+                  break
+                  ;;
+                missing | draft) ;;
+                *)
+                  echo "::error::Unexpected release convergence state: ${final_state}." >&2
+                  exit 1
+                  ;;
+              esac
+            else
+              lookup_error="$selected_releases"
+              final_state=unavailable
+            fi
+            if [ "$retry_delay" -eq 0 ]; then
+              echo "::error::Release ${RELEASE_TAG} did not converge to a published normal release after bounded retries (last state: ${final_state})." >&2
+              exit 1
+            fi
+            if [ "$final_state" = unavailable ]; then
+              echo "Published release lookup has not succeeded yet: ${lookup_error}" >&2
+            else
+              echo "Release ${RELEASE_TAG} has not converged to published (state=${final_state})."
+            fi
+            echo "Retrying release verification in ${retry_delay}s."
+            sleep "$retry_delay"
+          done
+          assert_tag_is_target "$RELEASE_TAG"
           assert_target_is_on_main "after release publication"
           echo "Verified published release ${RELEASE_TAG} at ${TARGET_SHA} with no uploaded assets."
     timeout-minutes: 60


### PR DESCRIPTION
## O que mudou

A verificação pós-publicação agora consulta a release publicada diretamente pela tag e repete somente leituras GET com backoff limitado (máximo de 30 segundos).

## Causa raiz

Um `gh release create` retornou sucesso, mas a leitura agregada feita menos de um segundo depois ainda não enxergou a release. O rerun passou, confirmando uma corrida de consistência de leitura, não uma falha da mutação.

## Segurança e impacto

- não repete criação, edição ou exclusão de release;
- preserva as validações de prerelease, assets, target SHA e ancestralidade em `main`;
- falha imediatamente para metadata inválida;
- falha fechada se a release não ficar visível dentro do limite;
- mantém as permissões e toda a lógica anterior inalteradas.

## Validação

- testes comportamentais do fragmento shell literal: sucesso tardio, exaustão e metadata inválida;
- ShellCheck 0.11.0;
- actionlint 1.7.12;
- zizmor 1.28.0 em modo auditor: zero achados;
- `git diff --check`;
- revisão independente Ultrabrain + cross-review em andamento antes da mesclagem.

Documentação oficial: https://docs.github.com/en/rest/releases/releases#get-a-release-by-tag-name