### PR TITLE
fix(deps): update brace-expansion to 5.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1705,16 +1705,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {


### PR DESCRIPTION
## Summary

- updates the locked `brace-expansion` from 5.0.7 to the current patched 5.0.8
- closes the vulnerable `eslint > minimatch > brace-expansion` path reported by Scorecard
- changes no application source or direct dependency range

Security advisory: GHSA-mh99-v99m-4gvg.

## Verification

- fresh `npm ci`
- `npm audit --audit-level=high`: 0 vulnerabilities
- ESLint and Biome pass
- Vitest: 1 file, 8 tests pass
- Vite 8.1.5 production build passes
- public HTML formatting check passes