### PR TITLE
fix(security): não devolve o detalhe do erro do Vertex ao cliente — v01.11.01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [v01.11.01] - 2026-08-10
+
+### Segurança
+
+- **O detalhe do erro do Vertex deixa de sair na resposta ao cliente.** Em
+  `/api/analisar-ia` e `/api/tesouro-ipca-vision`, a falha de geração devolvia
+  `Falha na requisição AI Gemini: ${errMsg}` num corpo 500 — e a mensagem do
+  Vertex carrega o project id do GCP, o e-mail da service account e o caminho do
+  endpoint. O corpo agora é uma mensagem estável; o detalhe continua registrado
+  onde já estava, no `structuredLog` e no `error_detail` do `logAiUsage`.
+  Remanescente do R1 apontado na revisão do PR #198.
+
 ## [v01.11.00] - 2026-08-09
 
 **Migração do transporte de IA para o Vertex AI (Onda 3 do programa Gemini → Vertex).**

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@
 
 **Oráculo Financeiro** — dashboard de análise financeira focado em renda fixa indexada à inflação (LCI/CDB com IPCA+, Tesouro IPCA+ etc.) com análise contextual via Gemini AI no Vertex AI. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store + Cron Worker auxiliar para pre-warming de cache de taxa.
 
-**Status.** Stable. Current release: **v01.11.00**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
+**Status.** Stable. Current release: **v01.11.01**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 
 The version history at a glance:
 
 | Release         | Scope                                                                                                                                                                                                                                                                                                                                                             |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`v01.11.01`** | **Upstream error detail no longer reaches the client.** The 500 body from both AI endpoints echoed the raw Vertex error, which carries the GCP project id, the service-account e-mail and the endpoint path; the body is now a stable message and the detail stays in `structuredLog` and in the `logAiUsage` telemetry. |
 | **`v01.11.00`** | **Vertex AI migration.** AI transport moves from the Gemini API key (`@google/genai`) to Vertex AI REST v1 with service-account OAuth (`VERTEX_SA_KEY`); both AI endpoints now honor the admin model selectors (`modeloAnalise`/`modeloVision`) as configured, falling back to the validated default only when the selected model is unavailable on Vertex (404). Prompts, retry, telemetry, and rate limiting unchanged. |
 | **`v01.10.08`** | **Dependency security patch.** Updates transitive `protobufjs` to 7.6.5 and `brace-expansion` to 5.0.7, resolving GHSA-j3f2-48v5-ccww and GHSA-3jxr-9vmj-r5cp without changing application APIs. |
 | **`v01.10.07`** | **4-gate quality directive compliance.** Added Biome scripts, deploy workflow coverage after eslint, scoped Biome to source/functions, and applied cosmetic source formatting plus safe callback cleanup required by the gate.                                                                                |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported status
 
-Latest supported release: v01.11.00. The current main branch is also supported for security fixes until the next release is published.
+Latest supported release: v01.11.01. The current main branch is also supported for security fixes until the next release is published.
 
 ## Reporting a vulnerability
 

--- a/functions/api/analisar-ia.test.ts
+++ b/functions/api/analisar-ia.test.ts
@@ -21,6 +21,7 @@ const runtime = vi.hoisted(() => {
     count404Models: [] as string[],
     generate404Models: [] as string[],
     generate404Operation: 'generateContent',
+    generateFailure: null as Error | null,
     MockVertexHttpError,
   };
 });
@@ -45,6 +46,7 @@ vi.mock('./_shared/vertex', () => ({
       },
       generateContent: async (request: Record<string, unknown>) => {
         runtime.generateRequests.push(request);
+        if (runtime.generateFailure) throw runtime.generateFailure;
         if (runtime.generate404Models.includes(request.model as string)) {
           throw new runtime.MockVertexHttpError(
             `Vertex generateContent falhou (HTTP 404): Publisher Model \`${request.model}\` not found.`,
@@ -125,6 +127,7 @@ beforeEach(() => {
   runtime.count404Models.length = 0;
   runtime.generate404Models.length = 0;
   runtime.generate404Operation = 'generateContent';
+  runtime.generateFailure = null;
 });
 
 describe('/api/analisar-ia — transporte Vertex', () => {
@@ -231,6 +234,22 @@ describe('/api/analisar-ia — transporte Vertex', () => {
     const res = await onRequestPost(context(PAYLOAD_LCI, { VERTEX_SA_KEY: '{"sa":"x"}', BIGDATA_DB: createDb(null) }));
     expect(res.status).toBe(413);
     expect(runtime.generateRequests).toHaveLength(0);
+  });
+
+  it('não devolve o detalhe do erro do Vertex no corpo da resposta 500', async () => {
+    runtime.generateFailure = new runtime.MockVertexHttpError(
+      'Vertex generateContent falhou (HTTP 403): Permission denied on resource project lcv-ideas-and-software; caller vertex-sa@lcv-ideas-and-software.iam.gserviceaccount.com lacks aiplatform.endpoints.predict.',
+      403,
+      'generateContent',
+    );
+    const res = await onRequestPost(context(PAYLOAD_LCI, { VERTEX_SA_KEY: '{"sa":"x"}', BIGDATA_DB: createDb(null) }));
+
+    expect(res.status).toBe(500);
+    const body = await res.text();
+    expect(body).not.toContain('lcv-ideas-and-software');
+    expect(body).not.toContain('iam.gserviceaccount.com');
+    expect(body).not.toContain('aiplatform.endpoints.predict');
+    expect(JSON.parse(body)).toEqual({ ok: false, error: 'Falha na requisição AI Gemini.' });
   });
 
   it('retorna 500 com excerto quando a resposta do modelo não é JSON', async () => {

--- a/functions/api/analisar-ia.ts
+++ b/functions/api/analisar-ia.ts
@@ -1,5 +1,5 @@
 // Módulo: oraculo-financeiro/functions/api/analisar-ia.ts
-// Versão: v01.11.00
+// Versão: v01.11.01
 // Descrição: Migração para Vertex AI — service account OAuth (VERTEX_SA_KEY), REST v1 global, modelo do seletor do admin (modeloAnalise; padrão gemini-3.1-pro-preview), safetySettings e retry preservados. Prompt fiduciário preservado.
 
 import { DEFAULT_ORACULO_MODEL, loadConfiguredOraculoModel } from './_shared/oraculoModelConfig';
@@ -441,7 +441,10 @@ export const onRequestPost = async ({ env, request }: Context) => {
             });
             return {
               kind: 'http-response',
-              response: jsonResponse({ ok: false, error: `Falha na requisição AI Gemini: ${errMsg}` }, 500),
+              // O detalhe do erro fica no structuredLog e no error_detail do logAiUsage:
+              // a mensagem do Vertex carrega project id, e-mail da service account e
+              // caminho do endpoint, que não podem sair na resposta ao cliente.
+              response: jsonResponse({ ok: false, error: 'Falha na requisição AI Gemini.' }, 500),
             };
           }
           await new Promise((r) => setTimeout(r, 800));

--- a/functions/api/tesouro-ipca-vision.test.ts
+++ b/functions/api/tesouro-ipca-vision.test.ts
@@ -20,6 +20,7 @@ const runtime = vi.hoisted(() => {
     totalTokens: 570,
     count404Models: [] as string[],
     generate404Models: [] as string[],
+    generateFailure: null as Error | null,
     MockVertexHttpError,
   };
 });
@@ -44,6 +45,7 @@ vi.mock('./_shared/vertex', () => ({
       },
       generateContent: async (request: Record<string, unknown>) => {
         runtime.generateRequests.push(request);
+        if (runtime.generateFailure) throw runtime.generateFailure;
         if (runtime.generate404Models.includes(request.model as string)) {
           throw new runtime.MockVertexHttpError(
             `Vertex generateContent falhou (HTTP 404): Publisher Model \`${request.model}\` not found.`,
@@ -96,6 +98,7 @@ beforeEach(() => {
   runtime.totalTokens = 570;
   runtime.count404Models.length = 0;
   runtime.generate404Models.length = 0;
+  runtime.generateFailure = null;
 });
 
 describe('/api/tesouro-ipca-vision — transporte Vertex multimodal', () => {
@@ -105,6 +108,27 @@ describe('/api/tesouro-ipca-vision — transporte Vertex multimodal', () => {
     );
     expect(res.status).toBe(503);
     expect(runtime.generateRequests).toHaveLength(0);
+  });
+
+  it('não devolve o detalhe do erro do Vertex no corpo da resposta 500', async () => {
+    runtime.generateFailure = new runtime.MockVertexHttpError(
+      'Vertex generateContent falhou (HTTP 403): Permission denied on resource project lcv-ideas-and-software; caller vertex-sa@lcv-ideas-and-software.iam.gserviceaccount.com lacks aiplatform.endpoints.predict.',
+      403,
+      'generateContent',
+    );
+    const res = await onRequestPost(
+      context(
+        { imageBase64: 'QUJD', mimeType: 'application/pdf' },
+        { VERTEX_SA_KEY: '{"sa":"x"}', BIGDATA_DB: createDb(null) },
+      ),
+    );
+
+    expect(res.status).toBe(500);
+    const body = await res.text();
+    expect(body).not.toContain('lcv-ideas-and-software');
+    expect(body).not.toContain('iam.gserviceaccount.com');
+    expect(body).not.toContain('aiplatform.endpoints.predict');
+    expect(JSON.parse(body)).toEqual({ ok: false, error: 'Falha na requisição AI Gemini.' });
   });
 
   it('retorna 400 sem imageBase64 ou mimeType', async () => {

--- a/functions/api/tesouro-ipca-vision.ts
+++ b/functions/api/tesouro-ipca-vision.ts
@@ -1,5 +1,5 @@
 // Módulo: oraculo-financeiro/functions/api/tesouro-ipca-vision.ts
-// Versão: v01.11.00
+// Versão: v01.11.01
 // Descrição: OCR multimodal via Vertex AI (service account OAuth, REST v1 global) — extrai lotes do Tesouro IPCA+ a partir de imagens/PDFs de extratos; modelo do seletor do admin (modeloVision; padrão gemini-3.1-pro-preview).
 // Alinhado ao padrão do analisar-ia.ts: retry, thought filtering, jsonResponse, safety BLOCK_ONLY_HIGH.
 
@@ -270,7 +270,10 @@ Regras de Extração e Conversão:
             });
             return {
               kind: 'http-response',
-              response: jsonResponse({ ok: false, error: `Falha na requisição AI Gemini: ${errMsg}` }, 500),
+              // O detalhe do erro fica no structuredLog e no error_detail do logAiUsage:
+              // a mensagem do Vertex carrega project id, e-mail da service account e
+              // caminho do endpoint, que não podem sair na resposta ao cliente.
+              response: jsonResponse({ ok: false, error: 'Falha na requisição AI Gemini.' }, 500),
             };
           }
           await new Promise((r) => setTimeout(r, 800));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oraculo-financeiro",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oraculo-financeiro",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "lucide-react": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oraculo-financeiro",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Oráculo Financeiro — dashboard de análise financeira (LCI/CDB, IPCA+, Tesouro Direto) com IA Gemini via Vertex AI para análise contextual. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store.",
   "license": "AGPL-3.0-or-later",
   "author": "LCV Ideas & Software",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 // Módulo: oraculo-financeiro/src/App.tsx
-// Versão: v01.11.00
+// Versão: v01.11.01
 // Descrição: Frontend do Oráculo Financeiro — análise LCI/LCA e Tesouro IPCA+ com IA Gemini via Vertex AI.
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -29,7 +29,7 @@ import {
   taxaEfetivaAnualDoPeriodo,
 } from './lib/finance';
 
-const APP_VERSION = 'APP v01.11.00';
+const APP_VERSION = 'APP v01.11.01';
 
 type TabId = 'lci-lca' | 'tesouro-ipca';
 


### PR DESCRIPTION
Fecha o R1 da revisão do PR #198, o último remanescente da Onda 3.

## O vazamento

Os dois endpoints de IA respondiam a falha de geração assim:

```
functions/api/analisar-ia.ts:444
functions/api/tesouro-ipca-vision.ts:273
    response: jsonResponse({ ok: false, error: `Falha na requisição AI Gemini: ${errMsg}` }, 500),
```

`errMsg` é a mensagem crua do Vertex. Com service account, ela carrega o project id do GCP, o e-mail da SA e o caminho do endpoint. O teste novo prova isso com um 403 realista — o corpo que o cliente recebia hoje:

```
{"ok":false,"error":"Falha na requisição AI Gemini: Vertex generateContent falhou (HTTP 403): Permission denied on resource project lcv-ideas-and-software; caller vertex-sa@lcv-ideas-and-software.iam.gserviceaccount.com lacks aiplatform.endpoints.predict."}
```

Endpoints públicos, sem autenticação de usuário: bastava provocar uma falha para colher o inventário interno.

## A correção

O corpo passa a ser `{"ok":false,"error":"Falha na requisição AI Gemini."}` — mesmo estilo do 500 vizinho de resposta vazia. **Nenhuma capacidade de diagnóstico se perde**: o detalhe já era gravado duas vezes e continua sendo, no `structuredLog` de nível `warn` e no `error_detail` do `logAiUsage` (recorte de 200 chars no D1).

## TDD

RED observado nos dois arquivos antes de qualquer mudança de produção. O primeiro:

```
AssertionError: expected '{"ok":false,"error":"Falha na requisi…' not to contain 'lcv-ideas-and-software'
 ❯ functions/api/analisar-ia.test.ts:249:22
```

No segundo handler eu inverti a ordem por descuido, escrevendo a produção antes do teste; revertei com `git checkout --`, escrevi o teste, observei o RED e só então reapliquei.

O harness dos dois mocks ganhou um `generateFailure` — um modo de falha genérico, já que o existente (`generate404Models`) só produz o 404 de publisher model, que é o caminho de fallback de modelo, não o de erro.

## Verificação

`test` (**70/70 em 6 arquivos**), `lint`, `biome`, `build`, `format:public:check` e `git diff --check` — exit 0. Versão em todas as superfícies: `package.json`, `package-lock.json`, `src/App.tsx` (header + `APP_VERSION`), `README.md`, `SECURITY.md` e os headers de módulo dos dois handlers alterados — a convenção do repo é o header carregar a release em que aquele módulo mudou (`taxa-ipca-atual.ts` segue em v01.03.01).

## Auto-merge

Não armado. Fica aberto para o Copilot e o codex se manifestarem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
