### PR TITLE
fix(security): fixtures de teste com identificadores sintéticos — v01.11.02

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [v01.11.02] - 2026-08-10
+
+### Segurança
+
+- **A fixture dos testes da v01.11.01 deixa de commitar o project id real do
+  GCP.** Ao provar que o detalhe do Vertex não sai na resposta, o teste gravou
+  o project id de produção e um endereço de service account no repositório —
+  que é público. As fixtures passam a usar identificadores sintéticos
+  (`exemplo-projeto-000`) e a asserção fica mais forte: além dos tokens
+  isolados, verifica a ausência da mensagem upstream inteira. Achado do Copilot
+  na revisão do PR #202.
+
 ## [v01.11.01] - 2026-08-10
 
 ### Segurança

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@
 
 **Oráculo Financeiro** — dashboard de análise financeira focado em renda fixa indexada à inflação (LCI/CDB com IPCA+, Tesouro IPCA+ etc.) com análise contextual via Gemini AI no Vertex AI. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store + Cron Worker auxiliar para pre-warming de cache de taxa.
 
-**Status.** Stable. Current release: **v01.11.01**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
+**Status.** Stable. Current release: **v01.11.02**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 
 The version history at a glance:
 
 | Release         | Scope                                                                                                                                                                                                                                                                                                                                                             |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`v01.11.02`** | **Test fixtures no longer commit the real GCP project id.** The v01.11.01 regression tests proved the Vertex detail stays out of responses by hardcoding the actual project id and a service-account address into this public repository; fixtures now use synthetic identifiers and additionally assert that the whole upstream message is absent. |
 | **`v01.11.01`** | **Upstream error detail no longer reaches the client.** The 500 body from both AI endpoints echoed the raw Vertex error, which carries the GCP project id, the service-account e-mail and the endpoint path; the body is now a stable message and the detail stays in `structuredLog` and in the `logAiUsage` telemetry. |
 | **`v01.11.00`** | **Vertex AI migration.** AI transport moves from the Gemini API key (`@google/genai`) to Vertex AI REST v1 with service-account OAuth (`VERTEX_SA_KEY`); both AI endpoints now honor the admin model selectors (`modeloAnalise`/`modeloVision`) as configured, falling back to the validated default only when the selected model is unavailable on Vertex (404). Prompts, retry, telemetry, and rate limiting unchanged. |
 | **`v01.10.08`** | **Dependency security patch.** Updates transitive `protobufjs` to 7.6.5 and `brace-expansion` to 5.0.7, resolving GHSA-j3f2-48v5-ccww and GHSA-3jxr-9vmj-r5cp without changing application APIs. |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported status
 
-Latest supported release: v01.11.01. The current main branch is also supported for security fixes until the next release is published.
+Latest supported release: v01.11.02. The current main branch is also supported for security fixes until the next release is published.
 
 ## Reporting a vulnerability
 

--- a/functions/api/analisar-ia.test.ts
+++ b/functions/api/analisar-ia.test.ts
@@ -97,6 +97,12 @@ const PAYLOAD_LCI = {
   benchmarkDescricao: 'acima da mediana',
 };
 
+// Identificadores sintéticos de propósito: a fixture reproduz o FORMATO da mensagem
+// do Vertex (project id + service account + permissão), nunca o inventário real —
+// que é justamente o que este teste garante não sair na resposta.
+const SYNTHETIC_PROJECT_ID = 'exemplo-projeto-000';
+const VERTEX_UPSTREAM_DETAIL = `Vertex generateContent falhou (HTTP 403): Permission denied on resource project ${SYNTHETIC_PROJECT_ID}; caller sa-exemplo@${SYNTHETIC_PROJECT_ID}.iam.gserviceaccount.com lacks aiplatform.endpoints.predict.`;
+
 const createDb = (configJson: string | null): D1DatabaseLike => ({
   prepare: (query: string) => {
     const isModuleConfig = query.includes('admin_module_configs');
@@ -237,16 +243,13 @@ describe('/api/analisar-ia — transporte Vertex', () => {
   });
 
   it('não devolve o detalhe do erro do Vertex no corpo da resposta 500', async () => {
-    runtime.generateFailure = new runtime.MockVertexHttpError(
-      'Vertex generateContent falhou (HTTP 403): Permission denied on resource project lcv-ideas-and-software; caller vertex-sa@lcv-ideas-and-software.iam.gserviceaccount.com lacks aiplatform.endpoints.predict.',
-      403,
-      'generateContent',
-    );
+    runtime.generateFailure = new runtime.MockVertexHttpError(VERTEX_UPSTREAM_DETAIL, 403, 'generateContent');
     const res = await onRequestPost(context(PAYLOAD_LCI, { VERTEX_SA_KEY: '{"sa":"x"}', BIGDATA_DB: createDb(null) }));
 
     expect(res.status).toBe(500);
     const body = await res.text();
-    expect(body).not.toContain('lcv-ideas-and-software');
+    expect(body).not.toContain(VERTEX_UPSTREAM_DETAIL);
+    expect(body).not.toContain(SYNTHETIC_PROJECT_ID);
     expect(body).not.toContain('iam.gserviceaccount.com');
     expect(body).not.toContain('aiplatform.endpoints.predict');
     expect(JSON.parse(body)).toEqual({ ok: false, error: 'Falha na requisição AI Gemini.' });

--- a/functions/api/tesouro-ipca-vision.test.ts
+++ b/functions/api/tesouro-ipca-vision.test.ts
@@ -69,6 +69,12 @@ const LOTES = [
   { dataCompra: '2026-03-03', valorInvestido: 1011.09, taxaContratada: 7.59 },
 ];
 
+// Identificadores sintéticos de propósito: a fixture reproduz o FORMATO da mensagem
+// do Vertex (project id + service account + permissão), nunca o inventário real —
+// que é justamente o que este teste garante não sair na resposta.
+const SYNTHETIC_PROJECT_ID = 'exemplo-projeto-000';
+const VERTEX_UPSTREAM_DETAIL = `Vertex generateContent falhou (HTTP 403): Permission denied on resource project ${SYNTHETIC_PROJECT_ID}; caller sa-exemplo@${SYNTHETIC_PROJECT_ID}.iam.gserviceaccount.com lacks aiplatform.endpoints.predict.`;
+
 const createDb = (configJson: string | null): D1DatabaseLike => ({
   prepare: (query: string) => {
     const isModuleConfig = query.includes('admin_module_configs');
@@ -111,11 +117,7 @@ describe('/api/tesouro-ipca-vision — transporte Vertex multimodal', () => {
   });
 
   it('não devolve o detalhe do erro do Vertex no corpo da resposta 500', async () => {
-    runtime.generateFailure = new runtime.MockVertexHttpError(
-      'Vertex generateContent falhou (HTTP 403): Permission denied on resource project lcv-ideas-and-software; caller vertex-sa@lcv-ideas-and-software.iam.gserviceaccount.com lacks aiplatform.endpoints.predict.',
-      403,
-      'generateContent',
-    );
+    runtime.generateFailure = new runtime.MockVertexHttpError(VERTEX_UPSTREAM_DETAIL, 403, 'generateContent');
     const res = await onRequestPost(
       context(
         { imageBase64: 'QUJD', mimeType: 'application/pdf' },
@@ -125,7 +127,8 @@ describe('/api/tesouro-ipca-vision — transporte Vertex multimodal', () => {
 
     expect(res.status).toBe(500);
     const body = await res.text();
-    expect(body).not.toContain('lcv-ideas-and-software');
+    expect(body).not.toContain(VERTEX_UPSTREAM_DETAIL);
+    expect(body).not.toContain(SYNTHETIC_PROJECT_ID);
     expect(body).not.toContain('iam.gserviceaccount.com');
     expect(body).not.toContain('aiplatform.endpoints.predict');
     expect(JSON.parse(body)).toEqual({ ok: false, error: 'Falha na requisição AI Gemini.' });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oraculo-financeiro",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oraculo-financeiro",
-      "version": "1.11.1",
+      "version": "1.11.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "lucide-react": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oraculo-financeiro",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Oráculo Financeiro — dashboard de análise financeira (LCI/CDB, IPCA+, Tesouro Direto) com IA Gemini via Vertex AI para análise contextual. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store.",
   "license": "AGPL-3.0-or-later",
   "author": "LCV Ideas & Software",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 // Módulo: oraculo-financeiro/src/App.tsx
-// Versão: v01.11.01
+// Versão: v01.11.02
 // Descrição: Frontend do Oráculo Financeiro — análise LCI/LCA e Tesouro IPCA+ com IA Gemini via Vertex AI.
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -29,7 +29,7 @@ import {
   taxaEfetivaAnualDoPeriodo,
 } from './lib/finance';
 
-const APP_VERSION = 'APP v01.11.01';
+const APP_VERSION = 'APP v01.11.02';
 
 type TabId = 'lci-lca' | 'tesouro-ipca';
 


### PR DESCRIPTION
Follow-up do achado do Copilot em #202, que mergeou antes da correção.

## O problema

O teste de regressão da v01.11.01 provava que o detalhe do Vertex não sai na resposta — gravando, para isso, o project id de produção e um endereço de service account no repositório. Mesmo inventário que o patch tirou do corpo HTTP, agora versionado no git.

E não era espelho de algo já público:

```
$ gh repo view LCV-Ideas-Software/oraculo-financeiro --json visibility --jq .visibility
PUBLIC

$ git grep -n "<project-id>" origin/main
functions/api/analisar-ia.test.ts:241        (fixture)
functions/api/analisar-ia.test.ts:249        (asserção)
functions/api/tesouro-ipca-vision.test.ts:115  (fixture)
functions/api/tesouro-ipca-vision.test.ts:128  (asserção)
```

As quatro linhas eram as do PR #202. A fixture publicou o dado.

## A correção

Identificadores sintéticos (`exemplo-projeto-000` e a service account correspondente), içados para uma constante `VERTEX_UPSTREAM_DETAIL` em cada arquivo de teste. A fixture continua reproduzindo o **formato** real da mensagem do Vertex — project id, service account e permissão negada —, que é o que dá sentido ao teste.

Atendendo ao segundo ponto do Copilot, a asserção ficou mais forte do que era: além dos tokens isolados, verifica a ausência da mensagem upstream **inteira**.

```ts
expect(body).not.toContain(VERTEX_UPSTREAM_DETAIL);
expect(body).not.toContain(SYNTHETIC_PROJECT_ID);
expect(body).not.toContain('iam.gserviceaccount.com');
expect(body).not.toContain('aiplatform.endpoints.predict');
```

## Prova de que a asserção continua com dentes

Mudança só em teste não tem RED natural, então validei por mutação. Reintroduzindo a interpolação no handler:

```
AssertionError: expected '{"ok":false,"error":"Falha na requisi…' not to contain 'Vertex generateContent falhou (HTTP 4…'
      Tests  1 failed | 11 skipped (12)
```

Handler restaurado com `git checkout --`, suíte de volta a **70/70**.

## Verificação

`test` (70/70 em 6 arquivos), `lint`, `biome`, `build`, `format:public:check` e `git diff --check` — exit 0. `git grep` pelo project id de produção no working tree retorna vazio. Versão sincronizada em `package.json`, `package-lock.json`, `src/App.tsx` (header + `APP_VERSION`), `README.md` e `SECURITY.md`. Os headers dos dois handlers permanecem em v01.11.01 — eles não mudaram neste patch, e a convenção do repo é o header carregar a release em que o módulo mudou.

O texto do CHANGELOG descreve o dado sem repeti-lo, para não reintroduzir pelo changelog o que a correção tira do teste.

## Auto-merge

Não armado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
