### PR TITLE
fix(ci): bootstrap native auto-merge v2.1.1

### DIFF
--- a/.github/workflows/native-auto-merge.yml
+++ b/.github/workflows/native-auto-merge.yml
@@ -6,29 +6,62 @@ on:
       - CodeQL
     types:
       - completed
+  pull_request_target:
+    types:
+      - review_requested
 
 permissions: write-all
 
 concurrency:
-  group: native-auto-merge-${{ github.repository }}-${{ github.event.workflow_run.head_sha }}
+  group: native-auto-merge-${{ github.repository }}-${{ github.event.workflow_run.id || github.run_id }}
   cancel-in-progress: false
 
 jobs:
   enable:
     name: Enable native auto-merge
-    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    if: >-
+      ${{
+        (
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.event == 'pull_request'
+        ) ||
+        (
+          github.event_name == 'pull_request_target' &&
+          github.event.action == 'review_requested' &&
+          github.event.requested_reviewer.id == 175728472 &&
+          github.event.pull_request.base.ref == 'main' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        )
+      }}
     runs-on: ubuntu-latest
     permissions: write-all
     environment: dependabot-automation
-    timeout-minutes: 5
+    timeout-minutes: 30
     steps:
       - name: Enable GitHub native auto-merge
-        uses: LCV-Ideas-Software/.github/native-auto-merge@4058fad11eca7c2eb4e9296108667ef6199a6356 # v2.0.0
+        if: ${{ github.event_name == 'workflow_run' }}
+        uses: LCV-Ideas-Software/.github/native-auto-merge@faa9f91026f33adacc6b01643aad46bf3d841344 # native-auto-merge/v2.1.1
         with:
           automation_token: ${{ secrets.LCV_AUTOMATION_TOKEN }}
           event_repository: ${{ github.event.repository.full_name }}
           workflow_name: ${{ github.event.workflow_run.name }}
+          workflow_path: ${{ github.event.workflow_run.path }}
+          workflow_display_title: ${{ github.event.workflow_run.display_title }}
           workflow_status: ${{ github.event.workflow_run.status }}
           workflow_event: ${{ github.event.workflow_run.event }}
           workflow_head_sha: ${{ github.event.workflow_run.head_sha }}
+          workflow_actor_id: ${{ github.event.workflow_run.actor.id }}
           workflow_pull_requests: ${{ toJSON(github.event.workflow_run.pull_requests) }}
+      - name: Reconcile requested Copilot review
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: LCV-Ideas-Software/.github/native-auto-merge@faa9f91026f33adacc6b01643aad46bf3d841344 # native-auto-merge/v2.1.1
+        with:
+          automation_token: ${{ secrets.LCV_AUTOMATION_TOKEN }}
+          event_repository: ${{ github.event.repository.full_name }}
+          event_action: ${{ github.event.action }}
+          pull_number: ${{ github.event.pull_request.number }}
+          pull_head_sha: ${{ github.event.pull_request.head.sha }}
+          pull_head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+          pull_base_ref: ${{ github.event.pull_request.base.ref }}
+          requested_reviewer_id: ${{ github.event.requested_reviewer.id }}
+          trigger_run_id: ${{ github.run_id }}


### PR DESCRIPTION
## Objetivo

Primeiro estágio do canário de governança: coloca o wrapper confiável `native-auto-merge` v2.1.1 na branch principal antes de exercitar seus novos wake-ups.

## Alterações

- adiciona `pull_request_target/review_requested` para reconciliação do Copilot;
- passa a proveniência completa do `workflow_run`;
- aumenta o timeout para comportar a janela silenciosa de revisão;
- mantém o PAT somente no environment protegido `dependabot-automation`;
- fixa a Action no SHA imutável da release assinada `native-auto-merge/v2.1.1`.

## Validação

- `actionlint .github/workflows/native-auto-merge.yml`;
- `git diff --check`;
- diff exclusivo do workflow.

Este PR é deliberadamente apenas o bootstrap. Um segundo PR, depois deste entrar em `main`, validará em runtime `workflow_run`, `pull_request_target` e o gate de feedback no `merge_group`.