### PR TITLE
fix(ci): bootstrap native auto-merge v2.1.4

### DIFF
--- a/.github/workflows/native-auto-merge.yml
+++ b/.github/workflows/native-auto-merge.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Enable GitHub native auto-merge
         if: ${{ github.event_name == 'workflow_run' }}
-        uses: LCV-Ideas-Software/.github/native-auto-merge@faa9f91026f33adacc6b01643aad46bf3d841344 # native-auto-merge/v2.1.1
+        uses: LCV-Ideas-Software/.github/native-auto-merge@231cd33f27c260a6b01fec26aa1d0eb606e1ee2d # native-auto-merge/v2.1.4
         with:
           automation_token: ${{ secrets.LCV_AUTOMATION_TOKEN }}
           event_repository: ${{ github.event.repository.full_name }}
@@ -54,7 +54,7 @@ jobs:
           workflow_pull_requests: ${{ toJSON(github.event.workflow_run.pull_requests) }}
       - name: Reconcile requested Copilot review
         if: ${{ github.event_name == 'pull_request_target' }}
-        uses: LCV-Ideas-Software/.github/native-auto-merge@faa9f91026f33adacc6b01643aad46bf3d841344 # native-auto-merge/v2.1.1
+        uses: LCV-Ideas-Software/.github/native-auto-merge@231cd33f27c260a6b01fec26aa1d0eb606e1ee2d # native-auto-merge/v2.1.4
         with:
           automation_token: ${{ secrets.LCV_AUTOMATION_TOKEN }}
           event_repository: ${{ github.event.repository.full_name }}


### PR DESCRIPTION
## Objetivo

Atualiza somente os dois wake-up paths privilegiados de Native Auto-merge da default branch para o runtime assinado e imutável native-auto-merge/v2.1.4, commit 231cd33f27c260a6b01fec26aa1d0eb606e1ee2d.

## Por que separado

pull_request_target e workflow_run sempre leem o workflow da default branch. Este bootstrap mínimo permite comprovar esses dois caminhos no rollout completo do PR #205 sem antecipar o novo gate de merge_group.

## Validação

- RED: a default branch continha zero das duas referências v2.1.4 esperadas;
- GREEN: exatamente duas referências v2.1.4 e nenhuma referência v2.1.1 residual neste wrapper;
- actionlint, Prettier 3.9.6 e git diff --check verdes;
- commit assinado e verificado pelo GitHub;
- sem alteração de permissões, eventos, inputs ou lógica.

Não haverá merge administrativo, direto ou bypass; este PR deve passar pela fila nativa SQUASH/ALLGREEN.