### PR TITLE
security: sanitiza o detalhe de erro de IA antes do log e do D1 (resíduo R1 do #198)

### DIFF
--- a/functions/api/_shared/vertex.test.ts
+++ b/functions/api/_shared/vertex.test.ts
@@ -520,9 +520,9 @@ describe('sanitizeAiErrorDetail', () => {
   });
 
   it('classifica erro de configuracao da SA key por prefixo, sem ecoar o campo', () => {
-    expect(sanitizeAiErrorDetail(new Error('VERTEX_SA_KEY inválido: campo obrigatório ausente ou vazio: private_key'))).toBe(
-      'sa_key_config_invalida',
-    );
+    expect(
+      sanitizeAiErrorDetail(new Error('VERTEX_SA_KEY inválido: campo obrigatório ausente ou vazio: private_key')),
+    ).toBe('sa_key_config_invalida');
   });
 
   it('classifica resposta vazia do modelo', () => {

--- a/functions/api/_shared/vertex.test.ts
+++ b/functions/api/_shared/vertex.test.ts
@@ -544,6 +544,13 @@ describe('sanitizeAiErrorDetail', () => {
     expect(sanitizeAiErrorDetail(err)).toBe('erro_nao_classificado_TypeError');
   });
 
+  it('um Error.name envenenado (gravavel) nao atravessa - vira o rotulo fixo', () => {
+    const err = new Error('qualquer');
+    err.name = 'sa@exemplo-projeto-000.iam.gserviceaccount.com: 403';
+    expect(sanitizeAiErrorDetail(err)).toBe('erro_nao_classificado_desconhecido');
+    expect(sanitizeAiErrorDetail(err)).not.toMatch(/@|gserviceaccount|403/u);
+  });
+
   it('trata lancamentos que nem sao Error', () => {
     expect(sanitizeAiErrorDetail('string qualquer com segredo-de-teste')).toBe('erro_nao_error');
     expect(sanitizeAiErrorDetail(undefined)).toBe('erro_nao_error');

--- a/functions/api/_shared/vertex.test.ts
+++ b/functions/api/_shared/vertex.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { VertexGenAI, VertexHttpError } from './vertex';
+import { sanitizeAiErrorDetail, VertexGenAI, VertexHttpError } from './vertex';
 
 const te = new TextEncoder();
 
@@ -504,5 +504,48 @@ describe('regressão workerd e erros diagnósticos', () => {
       fetchImpl: mock.fetchImpl,
     });
     await expect(partial.models.countTokens({ model: 'm', contents: 'x' })).rejects.toThrow(/private_key/u);
+  });
+});
+
+describe('sanitizeAiErrorDetail', () => {
+  it('reduz VertexHttpError a operacao + status numerico, sem a mensagem do provedor', () => {
+    const err = new VertexHttpError(
+      'Vertex generateContent falhou (HTTP 403): {"error":{"message":"Permission denied on projects/proj-x by sa@exemplo-projeto-000.iam.gserviceaccount.com"}}',
+      403,
+      'generateContent',
+    );
+    const detail = sanitizeAiErrorDetail(err);
+    expect(detail).toBe('vertex_generateContent_http_403');
+    expect(detail).not.toMatch(/proj-x|gserviceaccount|Permission/u);
+  });
+
+  it('classifica erro de configuracao da SA key por prefixo, sem ecoar o campo', () => {
+    expect(sanitizeAiErrorDetail(new Error('VERTEX_SA_KEY inválido: campo obrigatório ausente ou vazio: private_key'))).toBe(
+      'sa_key_config_invalida',
+    );
+  });
+
+  it('classifica resposta vazia do modelo', () => {
+    expect(sanitizeAiErrorDetail(new Error('Gemini retornou resposta vazia.'))).toBe('resposta_vazia');
+    expect(
+      sanitizeAiErrorDetail(new Error('Gemini retornou resposta vazia ou bloqueada pelos filtros de segurança.')),
+    ).toBe('resposta_vazia');
+  });
+
+  it('classifica timeout/abort pelo name do erro', () => {
+    const abort = new Error('The operation was aborted for https://endpoint-interno.exemplo.com');
+    abort.name = 'AbortError';
+    expect(sanitizeAiErrorDetail(abort)).toBe('timeout');
+    expect(sanitizeAiErrorDetail(abort)).not.toMatch(/endpoint-interno/u);
+  });
+
+  it('nunca ecoa a mensagem de um erro desconhecido - so o name da classe', () => {
+    const err = new TypeError('fetch failed: https://url-interna.exemplo.com com token xoxb-token-de-teste');
+    expect(sanitizeAiErrorDetail(err)).toBe('erro_nao_classificado_TypeError');
+  });
+
+  it('trata lancamentos que nem sao Error', () => {
+    expect(sanitizeAiErrorDetail('string qualquer com segredo-de-teste')).toBe('erro_nao_error');
+    expect(sanitizeAiErrorDetail(undefined)).toBe('erro_nao_error');
   });
 });

--- a/functions/api/_shared/vertex.ts
+++ b/functions/api/_shared/vertex.ts
@@ -93,6 +93,28 @@ export class VertexHttpError extends Error {
   }
 }
 
+/**
+ * Reduz um erro do caminho de IA a um detalhe de vocabulário CONSTANTE, seguro
+ * para structuredLog e para o error_detail persistido no D1. A mensagem crua do
+ * Vertex carrega project id, e-mail da service account e caminho do endpoint —
+ * nada dela é ecoado: a classificação usa só campos estruturados nossos
+ * (status/operation do VertexHttpError, name do erro) e prefixos de mensagens
+ * que ESTE código constrói antes de qualquer conteúdo do provedor.
+ */
+export function sanitizeAiErrorDetail(error: unknown): string {
+  if (error instanceof VertexHttpError) {
+    return `vertex_${error.operation}_http_${error.status}`;
+  }
+  if (error instanceof Error) {
+    if (error.name === 'AbortError' || error.name === 'TimeoutError') return 'timeout';
+    if (error.message.startsWith('VERTEX_SA_KEY')) return 'sa_key_config_invalida';
+    if (error.message.startsWith('Resposta do token endpoint sem access_token')) return 'oauth_token_ausente';
+    if (error.message.startsWith('Gemini retornou resposta vazia')) return 'resposta_vazia';
+    return `erro_nao_classificado_${error.name}`;
+  }
+  return 'erro_nao_error';
+}
+
 const OAUTH_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
 const OAUTH_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:jwt-bearer';
 const JWT_LIFETIME_S = 3600; // máximo permitido pelo fluxo server-to-server do Google

--- a/functions/api/_shared/vertex.ts
+++ b/functions/api/_shared/vertex.ts
@@ -110,7 +110,10 @@ export function sanitizeAiErrorDetail(error: unknown): string {
     if (error.message.startsWith('VERTEX_SA_KEY')) return 'sa_key_config_invalida';
     if (error.message.startsWith('Resposta do token endpoint sem access_token')) return 'oauth_token_ausente';
     if (error.message.startsWith('Gemini retornou resposta vazia')) return 'resposta_vazia';
-    return `erro_nao_classificado_${error.name}`;
+    // Error.name é GRAVÁVEL: só atravessa se casar com um identificador
+    // estrito (sem @, :, /, espaço) — um name envenenado vira o rótulo fixo.
+    const safeName = /^[A-Za-z][A-Za-z0-9]{0,39}$/u.test(error.name) ? error.name : 'desconhecido';
+    return `erro_nao_classificado_${safeName}`;
   }
   return 'erro_nao_error';
 }

--- a/functions/api/analisar-ia.test.ts
+++ b/functions/api/analisar-ia.test.ts
@@ -28,6 +28,11 @@ const runtime = vi.hoisted(() => {
 
 vi.mock('./_shared/vertex', () => ({
   VertexHttpError: runtime.MockVertexHttpError,
+  // Espelha a semantica do sanitizador real sobre a classe MOCK (instanceof).
+  sanitizeAiErrorDetail: (error: unknown) =>
+    error instanceof runtime.MockVertexHttpError
+      ? `vertex_${error.operation}_http_${error.status}`
+      : 'erro_nao_classificado_mock',
   VertexGenAI: class {
     constructor(options: Record<string, unknown>) {
       runtime.constructorOptions.push(options);

--- a/functions/api/analisar-ia.ts
+++ b/functions/api/analisar-ia.ts
@@ -385,7 +385,11 @@ export const onRequestPost = async ({ env, request }: Context) => {
         }
       } catch (countError) {
         if (signalModelUnavailable && isModelUnavailable(countError)) return { kind: 'model-unavailable' };
-        structuredLog('warn', 'Token count failed', { endpoint: 'analisar-ia', error: String(countError) });
+        // A mint OAuth roda dentro do countTokens: o erro cru carrega SA/endpoint.
+        structuredLog('warn', 'Token count failed', {
+          endpoint: 'analisar-ia',
+          error: sanitizeAiErrorDetail(countError),
+        });
       }
 
       for (let tentativa = 0; tentativa < 2; tentativa++) {

--- a/functions/api/analisar-ia.ts
+++ b/functions/api/analisar-ia.ts
@@ -4,7 +4,7 @@
 
 import { DEFAULT_ORACULO_MODEL, loadConfiguredOraculoModel } from './_shared/oraculoModelConfig';
 import { type D1DatabaseLike, enforceRateLimit, jsonResponse, requireAllowedOrigin } from './_shared/security';
-import { VertexGenAI, VertexHttpError } from './_shared/vertex';
+import { sanitizeAiErrorDetail, VertexGenAI, VertexHttpError } from './_shared/vertex';
 
 // ─── TYPES ────────────────────────────────────────────────────────────────────
 
@@ -423,11 +423,13 @@ export const onRequestPost = async ({ env, request }: Context) => {
           throw new Error('Gemini retornou resposta vazia.');
         } catch (error) {
           if (signalModelUnavailable && isModelUnavailable(error)) return { kind: 'model-unavailable' };
-          const errMsg = error instanceof Error ? error.message : String(error);
+          // R1 do PR #198 (issue #234): a mensagem crua do Vertex carrega
+          // project id, e-mail da SA e endpoint — nem log nem D1 a recebem.
+          const errDetail = sanitizeAiErrorDetail(error);
           structuredLog('warn', 'Falha ao requisitar Gemini', {
             endpoint: 'analisar-ia',
             attempt: tentativa + 1,
-            error: errMsg,
+            error: errDetail,
           });
           if (tentativa === 1) {
             void logAiUsage(env?.BIGDATA_DB, {
@@ -437,7 +439,7 @@ export const onRequestPost = async ({ env, request }: Context) => {
               output_tokens: 0,
               latency_ms: Date.now() - _telStart,
               status: 'error',
-              error_detail: errMsg.slice(0, 200),
+              error_detail: errDetail,
             });
             return {
               kind: 'http-response',

--- a/functions/api/tesouro-ipca-vision.test.ts
+++ b/functions/api/tesouro-ipca-vision.test.ts
@@ -27,6 +27,11 @@ const runtime = vi.hoisted(() => {
 
 vi.mock('./_shared/vertex', () => ({
   VertexHttpError: runtime.MockVertexHttpError,
+  // Espelha a semantica do sanitizador real sobre a classe MOCK (instanceof).
+  sanitizeAiErrorDetail: (error: unknown) =>
+    error instanceof runtime.MockVertexHttpError
+      ? `vertex_${error.operation}_http_${error.status}`
+      : 'erro_nao_classificado_mock',
   VertexGenAI: class {
     constructor(options: Record<string, unknown>) {
       runtime.constructorOptions.push(options);

--- a/functions/api/tesouro-ipca-vision.ts
+++ b/functions/api/tesouro-ipca-vision.ts
@@ -211,9 +211,10 @@ Regras de Extração e Conversão:
         }
       } catch (countError) {
         if (signalModelUnavailable && isModelUnavailable(countError)) return { kind: 'model-unavailable' };
+        // A mint OAuth roda dentro do countTokens: o erro cru carrega SA/endpoint.
         structuredLog('warn', 'Token count failed in Vision', {
           endpoint: 'tesouro-ipca-vision',
-          error: String(countError),
+          error: sanitizeAiErrorDetail(countError),
         });
       }
 

--- a/functions/api/tesouro-ipca-vision.ts
+++ b/functions/api/tesouro-ipca-vision.ts
@@ -5,7 +5,7 @@
 
 import { DEFAULT_ORACULO_MODEL, loadConfiguredOraculoModel } from './_shared/oraculoModelConfig';
 import { type D1DatabaseLike, enforceRateLimit, jsonResponse, requireAllowedOrigin } from './_shared/security';
-import { VertexGenAI, VertexHttpError } from './_shared/vertex';
+import { sanitizeAiErrorDetail, VertexGenAI, VertexHttpError } from './_shared/vertex';
 
 // ─── TYPES ────────────────────────────────────────────────────────────────────
 
@@ -252,11 +252,13 @@ Regras de Extração e Conversão:
           throw new Error('Gemini retornou resposta vazia ou bloqueada pelos filtros de segurança.');
         } catch (error) {
           if (signalModelUnavailable && isModelUnavailable(error)) return { kind: 'model-unavailable' };
-          const errMsg = error instanceof Error ? error.message : String(error);
+          // R1 do PR #198 (issue #234): a mensagem crua do Vertex carrega
+          // project id, e-mail da SA e endpoint — nem log nem D1 a recebem.
+          const errDetail = sanitizeAiErrorDetail(error);
           structuredLog('warn', 'Falha ao requisitar Gemini (Vision)', {
             endpoint: 'tesouro-ipca-vision',
             attempt: tentativa + 1,
-            error: errMsg,
+            error: errDetail,
           });
           if (tentativa === 1) {
             void logAiUsage(env?.BIGDATA_DB, {
@@ -266,7 +268,7 @@ Regras de Extração e Conversão:
               output_tokens: 0,
               latency_ms: Date.now() - _telStart,
               status: 'error',
-              error_detail: errMsg.slice(0, 200),
+              error_detail: errDetail,
             });
             return {
               kind: 'http-response',


### PR DESCRIPTION
Fecha o resíduo R1 da review do PR [#198](<https://github.com/LCV-Ideas-Software/oraculo-financeiro/issues/198>): `errMsg` cru (mensagem do Vertex com project id, e-mail da SA e caminho do endpoint) alcançava o `structuredLog` e o `error_detail` persistido no `bigdata_db` em `analisar-ia.ts` e `tesouro-ipca-vision.ts` — `slice(0,200)` truncava sem sanitizar.

**Fix por construção:** novo `sanitizeAiErrorDetail` em `_shared/vertex.ts` reduz qualquer erro a vocabulário constante — `vertex_<operation>_http_<status>` (campos estruturados do `VertexHttpError`), `timeout`, `sa_key_config_invalida`, `oauth_token_ausente`, `resposta_vazia`, `erro_nao_classificado_<name>` — nunca ecoando texto do provedor. A resposta ao cliente já era constante e permanece intocada.

TDD: 6 casos novos do sanitizador (RED antes da implementação), incluindo a prova de que project id/SA/endpoint sintéticos não atravessam; os mocks dos dois endpoints ganharam espelho do sanitizador sobre a classe mock (o real usa `instanceof`). Suíte completa **76/76**, lint/biome/build/format verdes.

Closes LCV-Ideas-Software/oraculo-financeiro#234  <br>Fixes LCV-Ideas-Software/oraculo-financeiro#234

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)