### PR TITLE
docs: consolida o ferramental de lint — Biome permanece gate obrigatório (#212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Decidido
+
+- **Ferramental de lint consolidado por decisão do operador (17/08/2026, issue
+  #212): o Biome PERMANECE como gate obrigatório de CI**, ao lado do ESLint. A
+  direção declarada na v01.09.00 ("ESLint fica como único enforcer de hook
+  deps, Biome fica só como formatter") está **superada**: o arranjo vigente —
+  ESLint (`npm run lint`, com `eslint-plugin-react-hooks` como enforcer de
+  hook deps) E Biome (`npm run biome`, lint+format) como gates do `deploy.yml`
+  — é o desenho intencional, não contradição. Os dois cobrem classes de
+  problema distintas e o custo de manter ambos é um passo de CI.
+
 ### Changed
 
 - Dependencias de desenvolvimento atualizadas, incluindo `typescript-eslint` 8.67.0 e Wrangler 4.123.0; o override vulneravel que rebaixava `undici` foi removido e o pacote raiz agora e explicitamente privado.


### PR DESCRIPTION
Registra a decisão do operador (17/08/2026, opção A da triagem): **o Biome permanece gate obrigatório de CI**, ao lado do ESLint. A direção declarada na v01.09.00 ("ESLint único enforcer de hook deps, Biome só formatter") fica ⛔ superada no registro — o arranjo vigente (ESLint com react-hooks como enforcer de deps E `npm run biome` no deploy.yml) é desenho intencional, não contradição pendente. Docs-only; nenhuma mudança de workflow (o estado real já era este).

Closes #212
Fixes ORAFINC-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)