### PR TITLE
deps: complete Biome and globals inventories (ORAFINC-9)

### DIFF
--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -2,7 +2,7 @@
 
 | Componente | Versão | Licença Original | Modificado? | Link de Origem |
 |------------|--------|------------------|-------------|----------------|
-| @biomejs/biome | ^2.5.7 | MIT OR Apache-2.0 | Não | https://registry.npmjs.org/@biomejs/biome |
+| @biomejs/biome | ^2.5.8 | MIT OR Apache-2.0 | Não | https://registry.npmjs.org/@biomejs/biome |
 | @eslint/js | ^10.0.1 | MIT | Não | https://registry.npmjs.org/@eslint/js |
 | @types/node | ^26.2.0 | MIT | Não | https://registry.npmjs.org/@types/node |
 | @types/react | ^19.2.18 | MIT | Não | https://registry.npmjs.org/@types/react |
@@ -13,7 +13,7 @@
 | eslint-config-prettier | ^10.1.8 | MIT | Não | https://registry.npmjs.org/eslint-config-prettier |
 | eslint-plugin-react-hooks | ^7.1.1 | MIT | Não | https://registry.npmjs.org/eslint-plugin-react-hooks |
 | eslint-plugin-react-refresh | ^0.5.4 | MIT | Não | https://registry.npmjs.org/eslint-plugin-react-refresh |
-| globals | ^17.9.0 | MIT | Não | https://registry.npmjs.org/globals |
+| globals | ^17.10.0 | MIT | Não | https://registry.npmjs.org/globals |
 | lucide-react | ^1.31.0 | ISC | Não | https://registry.npmjs.org/lucide-react |
 | prettier | ^3.9.6 | MIT | Não | https://registry.npmjs.org/prettier |
 | react | ^19.2.8 | MIT | Não | https://registry.npmjs.org/react |

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "sanitize-html": "^2.17.6"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.5.7",
+        "@biomejs/biome": "^2.5.8",
         "@eslint/js": "^10.0.1",
         "@types/node": "^26.2.0",
         "@types/react": "^19.2.18",
@@ -279,9 +279,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.7.tgz",
-      "integrity": "sha512-zr8K/DcY5tYsQOQwqMJ0AWElo6QgmgNI7idXgXLhevVszlt8RGVpesEJPqx3ThazLaOwjJ5Y8fz3BtH5fGZNsw==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.8.tgz",
+      "integrity": "sha512-aeAeeJB9fSDc7Gq+2GqpQxA0qBj6gj1k2R6L1cYqGePKP/baIq1WX8y6B+D+nRsO5ViQL22K/8IwbqERW0q1nw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -295,20 +295,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.5.7",
-        "@biomejs/cli-darwin-x64": "2.5.7",
-        "@biomejs/cli-linux-arm64": "2.5.7",
-        "@biomejs/cli-linux-arm64-musl": "2.5.7",
-        "@biomejs/cli-linux-x64": "2.5.7",
-        "@biomejs/cli-linux-x64-musl": "2.5.7",
-        "@biomejs/cli-win32-arm64": "2.5.7",
-        "@biomejs/cli-win32-x64": "2.5.7"
+        "@biomejs/cli-darwin-arm64": "2.5.8",
+        "@biomejs/cli-darwin-x64": "2.5.8",
+        "@biomejs/cli-linux-arm64": "2.5.8",
+        "@biomejs/cli-linux-arm64-musl": "2.5.8",
+        "@biomejs/cli-linux-x64": "2.5.8",
+        "@biomejs/cli-linux-x64-musl": "2.5.8",
+        "@biomejs/cli-win32-arm64": "2.5.8",
+        "@biomejs/cli-win32-x64": "2.5.8"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.7.tgz",
-      "integrity": "sha512-vxo/Ls3/PYdQWyLhYYcgMOCzQypAjcY+iihS8M0wW03l16TCLW4zqZzGo75gm1VdCMj38hTVZ31KBWrZ4G9dJw==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.8.tgz",
+      "integrity": "sha512-mk1QON9PHllvvLN5gU3f4rMxeh4syK5p9OvKyWH6/W8ueh04uaC8TUXXByhGufWf/y5mQc03ZLM45zU+cmqMjA==",
       "cpu": [
         "arm64"
       ],
@@ -323,9 +323,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.7.tgz",
-      "integrity": "sha512-Cd3Ga61amT/Yl/0x8elP5hhGYaFy4bw6WuysTgf7oo8TA5tJ5A1k+DkVoJ2BHbTVil51gTX9VPzArnrlLJ3Kyg==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.8.tgz",
+      "integrity": "sha512-bsGwFMBNyHPyiLSsQcZJxdoRrg1V4JL+d7wEsvUBczlP9U9lwM+7mzQHxI4o1mhBsTmdOBbAb6fHU3Z3snN45w==",
       "cpu": [
         "x64"
       ],
@@ -340,9 +340,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.7.tgz",
-      "integrity": "sha512-rR2QE0yF2GYSuYuKIa7pKvODGJqnOH+2eDREAM8wV+mWKSkMQKdAp4zXEZfTaxY8PMoNONnpgSWcBCyLDPDOKg==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.8.tgz",
+      "integrity": "sha512-XmFiA0WPYFC+uiUDC8WRFzAIH9bo7vwQLav38Uoq4ETC+T/+uBi0TsYGJECkugY3r8USl3jc+Ae2/irAF6F2lQ==",
       "cpu": [
         "arm64"
       ],
@@ -360,9 +360,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.7.tgz",
-      "integrity": "sha512-xPI5yB6XlpDbNkS+bm1t42olw5c4l3UrlOmLg7KtLJvjvkNF/1V4tnUgfkylGIeb3u/T+BzMGYqgQhzjAoJzuQ==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.8.tgz",
+      "integrity": "sha512-VcJNbstduTHx83NGAdhp78/JOcP45BZHXL7yNsfI1uGzdUgegAz2s+mSoT7wK6PBNzLoqG0zDOXaz/RQYVtSiw==",
       "cpu": [
         "arm64"
       ],
@@ -380,9 +380,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.7.tgz",
-      "integrity": "sha512-FQgqJhscrqJUFptGaRSUJWlXAExwWcDwLuK49dvKfkQ1bB5SEEyFssnsxQY83Xm6jR0EbbX3+8+D5bfvYqUG2Q==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.8.tgz",
+      "integrity": "sha512-S5wcm9OBDvLHodD4PUaN488hCpco9QD/9ZxuYJiw4euWtr/oQvLR72z2ixItH8Wd5BCm6FZaeb+YNvOoM1xHtQ==",
       "cpu": [
         "x64"
       ],
@@ -400,9 +400,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.7.tgz",
-      "integrity": "sha512-rE5VZi+qtmPgQH+l7jVxYoZ18b/TiHEhulhMpjmCZH1PltSbjRcxNWywC3HZ9tYottG7ORkeTtoscBilKSBm0g==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.8.tgz",
+      "integrity": "sha512-kKmiyokeISRGq2FLwvr+TzsgBusfxaZ0FZNLcOYOpCK/78tRrEjeEBLvq3xLZMpqbANgJdRPI7vZX8ZL37u9/w==",
       "cpu": [
         "x64"
       ],
@@ -420,9 +420,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.7.tgz",
-      "integrity": "sha512-Oq4x0CCwP4jirrcTywXs5kOGZ4v5vuEP+gWrbtjApOA2CL9F3F9GlIdQIci8AKSCa/zURanMRpX/4wQ7Am6hHg==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.8.tgz",
+      "integrity": "sha512-nILH0mzm3Hi3iEdd7o7GpB8kBR/mSQwfQG/tyBqyNrY2GFtcgwfV9nV8xLmbtUpMNY/Oi0Ml1XgfR4flOdq+AA==",
       "cpu": [
         "arm64"
       ],
@@ -437,9 +437,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.7.tgz",
-      "integrity": "sha512-V+0wu/nrj2S+MhP4EQ0uHNolP0IALEsz45pg0WoKkHfDeh0+ItHwP/p7bX5RPoMOl9NkpHYWdYPhIcy2mACHvQ==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.8.tgz",
+      "integrity": "sha512-I2czzXTY61f3nFJxXoMDq80t7MivxDEnCjE+8sDKoFfcKMaoQdkqhIFQ3KyY0XLzeSpUBYeNAXgD+iOV/BU0VA==",
       "cpu": [
         "x64"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.4",
-        "globals": "^17.9.0",
+        "globals": "^17.10.0",
         "prettier": "^3.9.6",
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.67.0",
@@ -3480,9 +3480,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
-      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
+      "version": "17.10.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.10.0.tgz",
+      "integrity": "sha512-V0kztuWST2k8A/VbxAY8+L+7+Rgo3fyA24IHRLrZp7HOzJjV0gHSaZUjK9lpP/IrBSNite2tZ1prhRkinRu1CA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.4",
-    "globals": "^17.9.0",
+    "globals": "^17.10.0",
     "prettier": "^3.9.6",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.67.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "sanitize-html": "^2.17.6"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.7",
+    "@biomejs/biome": "^2.5.8",
     "@eslint/js": "^10.0.1",
     "@types/node": "^26.2.0",
     "@types/react": "^19.2.18",

--- a/public/legal/THIRDPARTY.md
+++ b/public/legal/THIRDPARTY.md
@@ -2,7 +2,7 @@
 
 | Componente | Versão | Licença Original | Modificado? | Link de Origem |
 |------------|--------|------------------|-------------|----------------|
-| @biomejs/biome | ^2.5.7 | MIT OR Apache-2.0 | Não | https://registry.npmjs.org/@biomejs/biome |
+| @biomejs/biome | ^2.5.8 | MIT OR Apache-2.0 | Não | https://registry.npmjs.org/@biomejs/biome |
 | @eslint/js | ^10.0.1 | MIT | Não | https://registry.npmjs.org/@eslint/js |
 | @types/node | ^26.2.0 | MIT | Não | https://registry.npmjs.org/@types/node |
 | @types/react | ^19.2.18 | MIT | Não | https://registry.npmjs.org/@types/react |
@@ -13,7 +13,7 @@
 | eslint-config-prettier | ^10.1.8 | MIT | Não | https://registry.npmjs.org/eslint-config-prettier |
 | eslint-plugin-react-hooks | ^7.1.1 | MIT | Não | https://registry.npmjs.org/eslint-plugin-react-hooks |
 | eslint-plugin-react-refresh | ^0.5.4 | MIT | Não | https://registry.npmjs.org/eslint-plugin-react-refresh |
-| globals | ^17.9.0 | MIT | Não | https://registry.npmjs.org/globals |
+| globals | ^17.10.0 | MIT | Não | https://registry.npmjs.org/globals |
 | lucide-react | ^1.31.0 | ISC | Não | https://registry.npmjs.org/lucide-react |
 | prettier | ^3.9.6 | MIT | Não | https://registry.npmjs.org/prettier |
 | react | ^19.2.8 | MIT | Não | https://registry.npmjs.org/react |


### PR DESCRIPTION
## Resumo

- consolida as atualizações propostas nos PRs #238 e #239;
- atualiza Biome para `2.5.8` e globals para `17.10.0` com os lockfiles correspondentes;
- alinha `THIRDPARTY.md` e `public/legal/THIRDPARTY.md` às versões efetivas;
- substitui dois carriers Dependabot incompletos por um carrier rastreável.

Refs #240
Linear: ORAFINC-9
Supersedes #238 and #239

## Validação

- `npm ci`
- `npm run biome`
- `npm run lint`
- `npm test` (6 arquivos / 77 testes)
- `npm run build`
- `npm run format:public:check`
- `npm audit --audit-level=low` (0 vulnerabilidades)
- `git diff --check`
- commits corretivos assinados localmente