### PR TITLE
chore(ci): adopt the official Linear Release action

### DIFF
--- a/.github/workflows/actions.lock
+++ b/.github/workflows/actions.lock
@@ -18,6 +18,7 @@ workflows:
         - 'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020'
     '.github/workflows/linear-release.yml':
         - 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
+        - 'linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205'
     '.github/workflows/pages.yml':
         - 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
         - 'actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d'
@@ -89,6 +90,11 @@ dependencies:
         commit: 'sha1-db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28'
         owner_id: 9919
         repo_id: 259445878
+    'linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205':
+        ref: 'v0.16.0'
+        commit: 'sha1-0a25abab892a91062ebf42260dbb2ce6277aa205'
+        owner_id: 46686594
+        repo_id: 1150447766
     'ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc':
         ref: '2d1146689b8cda280b9bc96326124645441f03bc'
         commit: 'sha1-2d1146689b8cda280b9bc96326124645441f03bc'

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -53,28 +53,20 @@ jobs:
           fetch-depth: 0 # histórico completo: o CLI varre commits desde a última release
           persist-credentials: false
 
-      # Download verificado por digest — sem wrapper de terceiro: o binário oficial
-      # do CLI só executa se o SHA-256 conferir com o valor gravado abaixo
-      # (recomputado localmente e conferido contra o digest declarado pela API do
-      # GitHub em 17/08/2026). Troca de versão exige atualizar URL e digest juntos,
-      # por desenho. Inventário e fronteira de confiança em THIRDPARTY.md do
-      # repositório de governança.
+      # Action oficial da Linear, pinada ao commit assinado da v0.16.0. A versão
+      # v0.16.0 do CLI é selecionada explicitamente; o instalador oficial ainda
+      # baixa esse artefato sem verificação criptográfica, lacuna rastreada em
+      # linear/linear-release-action#59.
       #
       # Best-effort por desenho: esta sincronização é um espelho opcional e sua
-      # falha (digest divergente, indisponibilidade, segredo expirado) NUNCA pode
+      # falha (indisponibilidade, erro do CLI, segredo expirado) NUNCA pode
       # bloquear portões que varrem todos os runs do SHA. O run conclui verde e a
       # falha fica visível na anotação do passo; commits não sincronizados embarcam
       # na release seguinte.
-      - name: Create Linear release (CLI verificado por digest)
+      - name: Create Linear release with the official action
         id: linear_release
         continue-on-error: true
-        env:
-          LINEAR_ACCESS_KEY: ${{ secrets.LINEAR_ACCESS_KEY }}
-          CLI_URL: https://github.com/linear/linear-release/releases/download/v0.15.0/linear-release-linux-x64
-          CLI_SHA256: 06eddce3f0d306fcdfed634105a57b02695b5c4fb40c42eb56d13feced729c99
-        run: |
-          bin="$RUNNER_TEMP/linear-release"
-          curl -fsSL "$CLI_URL" -o "$bin"
-          echo "$CLI_SHA256  $bin" | sha256sum -c -
-          chmod +x "$bin"
-          "$bin" sync
+        uses: linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205 # v0.16.0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          cli_version: v0.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Changed
 
+- O Linear Release passa a usar a action oficial da Linear v0.16.0, fixada por SHA, sem alterar o gatilho pós-Deploy, o SHA efetivamente publicado nem o comportamento best-effort. Um teste de contrato também preserva os dois deploys oficiais do Wrangler e registra que não há envio direto ao Slack neste repositório.
 - Dependencias de desenvolvimento atualizadas, incluindo `typescript-eslint` 8.67.0 e Wrangler 4.123.0; o override vulneravel que rebaixava `undici` foi removido e o pacote raiz agora e explicitamente privado.
 - CodeQL, Dependency Review, Zizmor, OpenSSF Scorecard, GitHub Pages e deploy Cloudflare passam a usar apenas implementacoes oficiais com permissoes minimas e referencias externas fixadas por SHA.
 - Os dois arquivos Wrangler passam a versionar o identificador autorizado da D1 existente. O UUID identifica o recurso, mas nao concede acesso; tokens e credenciais continuam em Secrets.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "biome": "biome check .",
     "biome:write": "biome check --write .",
     "preview": "vite preview",
-    "test": "vitest run",
+    "test": "vitest run && npm run test:official-actions",
+    "test:official-actions": "node --test scripts/official-actions-contract.mjs",
     "format": "biome format --write src",
     "format:public": "prettier --write \"**/index.html\"",
     "format:public:check": "prettier --check \"**/index.html\""

--- a/scripts/official-actions-contract.mjs
+++ b/scripts/official-actions-contract.mjs
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const CHECKOUT_SHA = "3d3c42e5aac5ba805825da76410c181273ba90b1";
+const LINEAR_ACTION_SHA = "0a25abab892a91062ebf42260dbb2ce6277aa205";
+const WRANGLER_ACTION_SHA = "ebbaa1584979971c8614a24965b4405ff95890e0";
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const workflowsDirectory = path.join(repositoryRoot, ".github", "workflows");
+
+function read(relativePath) {
+  return readFileSync(path.join(repositoryRoot, relativePath), "utf8");
+}
+
+function occurrences(text, fragment) {
+  return text.split(fragment).length - 1;
+}
+
+const linearRelease = read(".github/workflows/linear-release.yml");
+const deploy = read(".github/workflows/deploy.yml");
+const actionsLock = read(".github/workflows/actions.lock");
+const packageJson = JSON.parse(read("package.json"));
+const packageLock = JSON.parse(read("package-lock.json"));
+const allWorkflows = readdirSync(workflowsDirectory)
+  .filter((file) => /\.ya?ml$/u.test(file))
+  .map((file) => read(path.join(".github", "workflows", file)))
+  .join("\n");
+
+test("Linear Release remains tied to the exact successful Deploy SHA", () => {
+  assert.match(linearRelease, /workflow_run:/u);
+  assert.match(linearRelease, /workflows:\s*\n\s*- Deploy/u);
+  assert.match(linearRelease, /types:\s*\n\s*- completed/u);
+  assert.match(
+    linearRelease,
+    /github\.event\.workflow_run\.conclusion == 'success'/u,
+  );
+  assert.match(
+    linearRelease,
+    /github\.event\.workflow_run\.head_branch == 'main'/u,
+  );
+  assert.match(
+    linearRelease,
+    /group: linear-release-\$\{\{ github\.event\.workflow_run\.head_branch \}\}-\$\{\{ github\.event\.workflow_run\.conclusion \}\}/u,
+  );
+  assert.match(linearRelease, /cancel-in-progress: false/u);
+  assert.match(linearRelease, /environment: linear-release/u);
+  assert.match(linearRelease, /permissions:\s*\n\s*contents: read/u);
+  assert.match(
+    linearRelease,
+    new RegExp(`uses: actions/checkout@${CHECKOUT_SHA}`, "u"),
+  );
+  assert.match(
+    linearRelease,
+    /ref: \$\{\{ github\.event\.workflow_run\.head_sha \}\}/u,
+  );
+  assert.match(linearRelease, /fetch-depth: 0/u);
+  assert.match(linearRelease, /persist-credentials: false/u);
+  assert.match(linearRelease, /continue-on-error: true/u);
+});
+
+test("Linear Release uses the pinned official action and lock entry", () => {
+  const officialUse = `linear/linear-release-action@${LINEAR_ACTION_SHA}`;
+
+  assert.equal(occurrences(linearRelease, officialUse), 1);
+  assert.match(
+    linearRelease,
+    /access_key: \$\{\{ secrets\.LINEAR_ACCESS_KEY \}\}/u,
+  );
+  assert.match(linearRelease, /cli_version: v0\.16\.0/u);
+  assert.doesNotMatch(
+    linearRelease,
+    /CLI_URL|CLI_SHA256|linear-release-linux|curl\s+-|sha256sum/u,
+  );
+  assert.equal(occurrences(actionsLock, officialUse), 2);
+  assert.match(
+    actionsLock,
+    /'linear\/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205':[\s\S]*?ref: 'v0\.16\.0'/u,
+  );
+});
+
+test("both Cloudflare deploys remain on the official Wrangler action", () => {
+  const officialUse = `cloudflare/wrangler-action@${WRANGLER_ACTION_SHA}`;
+
+  assert.equal(occurrences(deploy, officialUse), 2);
+  assert.equal(occurrences(deploy, 'wranglerVersion: "4.123.0"'), 2);
+  assert.equal(
+    occurrences(
+      deploy,
+      "apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}",
+    ),
+    2,
+  );
+  assert.equal(
+    occurrences(
+      deploy,
+      "accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}",
+    ),
+    2,
+  );
+
+  const pages = deploy.indexOf(
+    "- name: Deploy Pages application with Wrangler",
+  );
+  const worker = deploy.indexOf("- name: Deploy Cron Worker with Wrangler");
+  assert.ok(pages >= 0 && worker > pages);
+  assert.match(
+    deploy.slice(pages, worker),
+    /workingDirectory: \.[\s\S]*command: pages deploy dist --project-name=oraculo-financeiro --branch=main --commit-dirty=true/u,
+  );
+  assert.match(
+    deploy.slice(worker),
+    /workingDirectory: \.[\s\S]*command: deploy --strict --config workers\/taxaipca-motor\/wrangler\.json/u,
+  );
+
+  assert.equal(packageJson.devDependencies.wrangler, "4.123.0");
+  assert.equal(
+    packageLock.packages["node_modules/wrangler"].version,
+    "4.123.0",
+  );
+  assert.equal(occurrences(actionsLock, officialUse), 2);
+});
+
+test("no direct Slack workflow is invented for this repository", () => {
+  assert.doesNotMatch(
+    allWorkflows,
+    /slackapi\/slack-github-action@|hooks\.slack\.com|slack\.com\/api\/chat\.postMessage|chat\.postMessage|SLACK_WEBHOOK|SLACK_BOT_TOKEN/u,
+  );
+});


### PR DESCRIPTION
## Summary

- replace the custom Linear Release CLI downloader with `linear/linear-release-action` v0.16.0 pinned to its immutable commit
- preserve the exact successful `Deploy` SHA, protected environment, least-privilege permissions, concurrency and best-effort behavior
- add a RED→GREEN contract that also preserves both official Wrangler deploys and proves Slack is not applicable
- regenerate and verify `actions.lock`

Closes #251
Linear: [ORAFINC-12](https://linear.app/lcv-ideas-software/issue/ORAFINC-12/maintenance-adotar-linear-release-oficial-preservando-os-deploys)

## Validation

- [x] `npm audit --audit-level=high`
- [x] `npm run lint`
- [x] `npm run biome`
- [x] `npm test` — 91 Vitest + 4 contract tests
- [x] `npm run build`
- [x] `npm run format:public:check`
- [x] `node scripts/verify-thirdparty.mjs`
- [x] `gh actions-lock --no-fix` — `valid: true`
- [x] `actionlint`
- [x] Zizmor pedantic on the changed workflow — no findings
- [x] Gitleaks on the diff — no findings
- [x] GitHub Actions changes use least-privilege permissions and immutable action SHAs.
- [x] Dependabot automation remains non-blocking for routine patch/minor updates.

## Security Notes

- [x] No secrets, credentials, tokens, or private infrastructure details were added.
- [x] No new deployment or cloud access was introduced.
- [x] The known upstream integrity gap remains tracked in linear/linear-release-action#59; the action and CLI versions are fixed, but this change is standardization rather than an integrity improvement.

Agent: Codex