### PR TITLE
docs(contacts): route conduct and support email (GIT-135)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -22,7 +22,7 @@ This applies to:
 
 Reports of violations can be sent privately to:
 
-**lcv@lcv.dev**
+**conductcode@lcv.dev**
 
 This is the same private channel used for security reports (see [SECURITY.md](./SECURITY.md)). Reports will be acknowledged within 48 hours and handled per the Contributor Covenant 3.0 enforcement ladder.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ By contributing, you agree your contribution is licensed under [AGPL-3.0-or-late
 
 ## Code of Conduct
 
-By participating, you agree to follow [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) (Contributor Covenant 3.0). Violations to `lcv@lcv.dev`.
+By participating, you agree to follow [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) (Contributor Covenant 3.0). Violations to `chamados@lcv.dev`.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ By contributing, you agree your contribution is licensed under [AGPL-3.0-or-late
 
 ## Code of Conduct
 
-By participating, you agree to follow [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) (Contributor Covenant 3.0). Violations to `chamados@lcv.dev`.
+By participating, you agree to follow [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) (Contributor Covenant 3.0). Report conduct violations to `conductcode@lcv.dev`. For general contribution support, contact `chamados@lcv.dev`.
 
 ---
 


### PR DESCRIPTION
## Summary

- Route conduct reports to conductcode@lcv.dev.
- Route contribution support to chamados@lcv.dev.

## Verification

- git diff --check
- Diff limited to CODE_OF_CONDUCT.md and CONTRIBUTING.md.
- Zero lcv@lcv.dev remains in the branch.

Refs LCV-Ideas-Software/github-operations#151
Linear: https://linear.app/lcv-ideas-software/issue/GIT-135/maintenance-padronizar-canais-de-conduta-e-chamados-na-frota