### PR TITLE
docs(conduct): separate security reporting channel (GIT-135)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -24,7 +24,7 @@ Reports of violations can be sent privately to:
 
 **conductcode@lcv.dev**
 
-This is the same private channel used for security reports (see [SECURITY.md](./SECURITY.md)). Reports will be acknowledged within 48 hours and handled per the Contributor Covenant 3.0 enforcement ladder.
+Security vulnerabilities must be reported separately through [SECURITY.md](./SECURITY.md) at **security@lcv.dev**. Conduct reports will be acknowledged within 48 hours and handled per the Contributor Covenant 3.0 enforcement ladder.
 
 All reporters will have their identity kept confidential.
 


### PR DESCRIPTION
## Summary

- Follow up #255 by keeping the conduct and security reporting channels distinct.
- Keep conduct reports at conductcode@lcv.dev.
- Route security vulnerabilities through SECURITY.md at security@lcv.dev.

## Verification

- git diff --check
- Diff limited to CODE_OF_CONDUCT.md.
- Zero lcv@lcv.dev remains in the branch.

Refs LCV-Ideas-Software/github-operations#151
Linear: https://linear.app/lcv-ideas-software/issue/GIT-135/maintenance-padronizar-canais-de-conduta-e-chamados-na-frota