### PR TITLE
fix(ci): preserve Dependabot cooldown and release queue (ORAFINC-13)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,8 @@ updates:
     cooldown:
       default-days: 7
       exclude:
-        - "*"
+        - "actions/*"
+        - "github/*"
     labels:
       - "dependencies"
       - "github-actions"

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -17,19 +17,12 @@ on:
 # Política enterprise (Discussion #150): sem write-all. Conjunto vazio no escopo do
 # workflow e grant mínimo declarado no job.
 permissions: {}
-# Agrupamento intencional: o CLI varre todos os commits desde a última release
-# (fetch-depth: 0). Se um run pendente for substituído por um mais novo, os
-# commits dele embarcam na release do run seguinte — nada se perde; releases
-# agrupam deploys em rajada por desenho, e o grupo evita corrida entre duas
-# criações de release simultâneas.
-# O grupo inclui a CONCLUSÃO do Deploy: o filtro do job (if) só age depois do
-# enfileiramento, então um run de Deploy falhado entraria no mesmo grupo e
-# poderia substituir na fila um run de sucesso pendente — deixando o SHA
-# publicado sem release até o próximo deploy. Com a conclusão na chave, runs de
-# falha (que o if pula) nunca deslocam runs de sucesso.
+# Cada Deploy bem-sucedido precisa gerar sua própria release. `queue: max`
+# preserva todos os runs pendentes do grupo, e a conclusão na chave mantém runs
+# falhados (que o job ignora) separados dos runs de sucesso.
 concurrency:
   group: linear-release-${{ github.event.workflow_run.head_branch }}-${{ github.event.workflow_run.conclusion }}
-  cancel-in-progress: false
+  queue: max
 jobs:
   linear_release:
     name: Linear Release
@@ -58,14 +51,11 @@ jobs:
       # baixa esse artefato sem verificação criptográfica, lacuna rastreada em
       # linear/linear-release-action#59.
       #
-      # Best-effort por desenho: esta sincronização é um espelho opcional e sua
-      # falha (indisponibilidade, erro do CLI, segredo expirado) NUNCA pode
-      # bloquear portões que varrem todos os runs do SHA. O run conclui verde e a
-      # falha fica visível na anotação do passo; commits não sincronizados embarcam
-      # na release seguinte.
+      # A sincronização falha de forma visível: indisponibilidade, erro do CLI ou
+      # segredo expirado deixam o workflow vermelho, evitando perder
+      # silenciosamente a release do SHA publicado.
       - name: Create Linear release with the official action
         id: linear_release
-        continue-on-error: true
         uses: linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205 # v0.16.0
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Changed
 
-- O Linear Release passa a usar a action oficial da Linear v0.16.0, fixada por SHA, sem alterar o gatilho pós-Deploy, o SHA efetivamente publicado nem o comportamento best-effort. Um teste de contrato também preserva os dois deploys oficiais do Wrangler e registra que não há envio direto ao Slack neste repositório.
+- O Linear Release passa a usar a action oficial da Linear v0.16.0, fixada por SHA, sem alterar o gatilho pós-Deploy nem o SHA efetivamente publicado. A fila usa `queue: max`, e falhas da action tornam o workflow vermelho. Um teste de contrato também preserva os dois deploys oficiais do Wrangler e registra que não há envio direto ao Slack neste repositório.
 - Dependencias de desenvolvimento atualizadas, incluindo `typescript-eslint` 8.67.0 e Wrangler 4.123.0; o override vulneravel que rebaixava `undici` foi removido e o pacote raiz agora e explicitamente privado.
 - CodeQL, Dependency Review, Zizmor, OpenSSF Scorecard, GitHub Pages e deploy Cloudflare passam a usar apenas implementacoes oficiais com permissoes minimas e referencias externas fixadas por SHA.
 - Os dois arquivos Wrangler passam a versionar o identificador autorizado da D1 existente. O UUID identifica o recurso, mas nao concede acesso; tokens e credenciais continuam em Secrets.

--- a/scripts/official-actions-contract.mjs
+++ b/scripts/official-actions-contract.mjs
@@ -48,7 +48,8 @@ test("Linear Release remains tied to the exact successful Deploy SHA", () => {
     linearRelease,
     /group: linear-release-\$\{\{ github\.event\.workflow_run\.head_branch \}\}-\$\{\{ github\.event\.workflow_run\.conclusion \}\}/u,
   );
-  assert.match(linearRelease, /cancel-in-progress: false/u);
+  assert.match(linearRelease, /queue: max/u);
+  assert.doesNotMatch(linearRelease, /cancel-in-progress:/u);
   assert.match(linearRelease, /environment: linear-release/u);
   assert.match(linearRelease, /permissions:\s*\n\s*contents: read/u);
   assert.match(
@@ -61,7 +62,7 @@ test("Linear Release remains tied to the exact successful Deploy SHA", () => {
   );
   assert.match(linearRelease, /fetch-depth: 0/u);
   assert.match(linearRelease, /persist-credentials: false/u);
-  assert.match(linearRelease, /continue-on-error: true/u);
+  assert.doesNotMatch(linearRelease, /continue-on-error:\s*true/u);
 });
 
 test("Linear Release uses the pinned official action and lock entry", () => {


### PR DESCRIPTION
## Summary
- keep the seven-day Dependabot cooldown for third-party GitHub Actions
- exempt only official actions/* and github/* software
- queue every pending Linear Release run with queue: max
- fail visibly when the official Linear Release action fails
- preserve triggers, concurrency group, action pins, permissions, secrets, and actions.lock

## Validation
- YAML converted with yq and asserted with jq
- gh actions-lock --verify-local: valid
- Zizmor: no findings
- git diff --check: clean
- actions.lock: byte-identical
- commit: GPG signature verified

Closes #257

Linear: https://linear.app/lcv-ideas-software/issue/ORAFINC-13
Refs LCV-Ideas-Software/github-operations#143

Official queue documentation: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency#example-queueing-multiple-pending-runs