### PR TITLE
fix(deps): usar o Wrangler selecionado pelo lockfile

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,7 +65,6 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: npm
           workingDirectory: .
-          wranglerVersion: "4.123.0"
           command: pages deploy dist --project-name=oraculo-financeiro --branch=main --commit-dirty=true
 
       - name: Deploy Cron Worker with Wrangler
@@ -75,5 +74,4 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: npm
           workingDirectory: .
-          wranglerVersion: "4.123.0"
           command: deploy --strict --config workers/taxaipca-motor/wrangler.json

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -24,4 +24,4 @@
 | typescript-eslint | ^8.67.0 | MIT | Não | https://registry.npmjs.org/typescript-eslint |
 | vite | ^8.2.1 | MIT | Não | https://registry.npmjs.org/vite |
 | vitest | ^4.1.10 | MIT | Não | https://registry.npmjs.org/vitest |
-| wrangler | 4.123.0 | MIT OR Apache-2.0 | Não | https://registry.npmjs.org/wrangler |
+| wrangler | 4.124.0 | MIT OR Apache-2.0 | Não | https://registry.npmjs.org/wrangler |

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "typescript-eslint": "^8.67.0",
         "vite": "^8.2.1",
         "vitest": "^4.1.10",
-        "wrangler": "4.123.0"
+        "wrangler": "4.124.0"
       },
       "engines": {
         "node": ">=22"
@@ -481,9 +481,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260811.1.tgz",
-      "integrity": "sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260815.1.tgz",
+      "integrity": "sha512-7PsLdcz6pT9EMd1EJGZEgMyYRfs0CHxGs62PS2L1w3s6+xGmQcRXKm/zoMftmqZF45JBa4MzFeownRKbRt/x5g==",
       "cpu": [
         "x64"
       ],
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260811.1.tgz",
-      "integrity": "sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260815.1.tgz",
+      "integrity": "sha512-60wtg8ng7FVWeOg/UMbZ9Ye0sslpRRAKoftPbdtuH2volq676quxVr6Zm2EjVULH/JFZeCn72dbLlrnbh0Mpcw==",
       "cpu": [
         "arm64"
       ],
@@ -515,9 +515,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260811.1.tgz",
-      "integrity": "sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260815.1.tgz",
+      "integrity": "sha512-MuqKIHPo0Qyo8MZMmy0lP2B5PeAL7f4T9Fu4Usk3QdbV4JIrKG/OoybN3Ign7m/Dff+L1Oo/ZHydB+hEg1ueFw==",
       "cpu": [
         "x64"
       ],
@@ -532,9 +532,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260811.1.tgz",
-      "integrity": "sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260815.1.tgz",
+      "integrity": "sha512-XNFtJ5rIqJxnY6ISjkfbhT/ODiWJ6LcBvNbntuPD6I/F2k7aZeKgPaXrvWvKde66LXyzFKzc8Hn+Ydx4shevQg==",
       "cpu": [
         "arm64"
       ],
@@ -549,9 +549,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260811.1.tgz",
-      "integrity": "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260815.1.tgz",
+      "integrity": "sha512-PiIUWrhbMg3quolwjgMvPOd75vKESjT4aDm7nL6mSjL5IOgmpO/zKstXnYfnEH3pq7sC0UCvKlF8ZPcfsh8NMw==",
       "cpu": [
         "x64"
       ],
@@ -2625,16 +2625,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2643,13 +2643,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.10",
+        "@vitest/spy": "4.1.11",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2670,9 +2670,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2683,13 +2683,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.10",
+        "@vitest/utils": "4.1.11",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2697,14 +2697,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2713,9 +2713,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2723,13 +2723,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -4080,16 +4080,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "5.20260811.1-alpha",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260811.1-alpha.tgz",
-      "integrity": "sha512-DtOG0BeanIxs2sH0smFvExZD89cBQwGckbHiFkRJrrNAUu3NGClZkUxqu+zy7HYfKBAgq935EMY49vIPm3JVdA==",
+      "version": "5.20260815.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260815.0-alpha.tgz",
+      "integrity": "sha512-YAaGj4Sh5f4fqHKiMQ8zRHDOOM5IGUVtMhnLIeyjuQfU+9P6hcOTrHUVtbfj/ZPay9Kzik4pWELB39pGgefjiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.35.2",
         "undici": "7.29.0",
-        "workerd": "1.20260811.1",
+        "workerd": "1.20260815.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -4685,9 +4685,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4913,19 +4913,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.10",
-        "@vitest/mocker": "4.1.10",
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/runner": "4.1.10",
-        "@vitest/snapshot": "4.1.10",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -4953,12 +4953,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.10",
-        "@vitest/browser-preview": "4.1.10",
-        "@vitest/browser-webdriverio": "4.1.10",
-        "@vitest/coverage-istanbul": "4.1.10",
-        "@vitest/coverage-v8": "4.1.10",
-        "@vitest/ui": "4.1.10",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -5056,9 +5056,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260811.1.tgz",
-      "integrity": "sha512-kh+FFm55JQ4ssxhHZV9VPdMQq3D1nHxNJgwxMtWGD4dGppJvLySdguTRDKgeNTvgq6heSz+6TTXyPSDGj8Yllw==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260815.1.tgz",
+      "integrity": "sha512-8bArFkHmlp7qFEKVPyNzDzHzS35gc2fg0PYBcDtaNLF7UCDryCX2BQnpkUkTHYIy824IRrHOTwOEoTj0sUO2Fg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -5069,17 +5069,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260811.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260811.1",
-        "@cloudflare/workerd-linux-64": "1.20260811.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260811.1",
-        "@cloudflare/workerd-windows-64": "1.20260811.1"
+        "@cloudflare/workerd-darwin-64": "1.20260815.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260815.1",
+        "@cloudflare/workerd-linux-64": "1.20260815.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260815.1",
+        "@cloudflare/workerd-windows-64": "1.20260815.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.123.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.123.0.tgz",
-      "integrity": "sha512-VXo2I1oa0x9aGAKIFPRSQPqTh0RBY5Ktl44YOhNmsJQFUdJKDA2vVTU6Xj+FC2koll6orJqWZN8jbXVIk9O67Q==",
+      "version": "4.124.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.124.0.tgz",
+      "integrity": "sha512-75euoZKjVTJYFy+Xhctt/5JlZL4M6A4xmovZsUlep+6GHcCm14n9VtdGzNIybOW2t8wuNxRj5iMUwjT5E7Ctog==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -5087,10 +5087,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "5.20260811.1-alpha",
+        "miniflare": "5.20260815.0-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260811.1"
+        "workerd": "1.20260815.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -5104,7 +5104,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260811.1"
+        "@cloudflare/workers-types": "^5.20260815.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "typescript-eslint": "^8.67.0",
     "vite": "^8.2.1",
     "vitest": "^4.1.10",
-    "wrangler": "4.123.0"
+    "wrangler": "4.124.0"
   },
   "overrides": {
     "picomatch": "4.0.4",

--- a/public/legal/THIRDPARTY.md
+++ b/public/legal/THIRDPARTY.md
@@ -24,4 +24,4 @@
 | typescript-eslint | ^8.67.0 | MIT | Não | https://registry.npmjs.org/typescript-eslint |
 | vite | ^8.2.1 | MIT | Não | https://registry.npmjs.org/vite |
 | vitest | ^4.1.10 | MIT | Não | https://registry.npmjs.org/vitest |
-| wrangler | 4.123.0 | MIT OR Apache-2.0 | Não | https://registry.npmjs.org/wrangler |
+| wrangler | 4.124.0 | MIT OR Apache-2.0 | Não | https://registry.npmjs.org/wrangler |

--- a/scripts/official-actions-contract.mjs
+++ b/scripts/official-actions-contract.mjs
@@ -27,6 +27,9 @@ const deploy = read(".github/workflows/deploy.yml");
 const actionsLock = read(".github/workflows/actions.lock");
 const packageJson = JSON.parse(read("package.json"));
 const packageLock = JSON.parse(read("package-lock.json"));
+const installedWrangler = JSON.parse(
+  read("node_modules/wrangler/package.json"),
+);
 const allWorkflows = readdirSync(workflowsDirectory)
   .filter((file) => /\.ya?ml$/u.test(file))
   .map((file) => read(path.join(".github", "workflows", file)))
@@ -87,21 +90,27 @@ test("Linear Release uses the pinned official action and lock entry", () => {
 
 test("both Cloudflare deploys remain on the official Wrangler action", () => {
   const officialUse = `cloudflare/wrangler-action@${WRANGLER_ACTION_SHA}`;
+  const installCommand = "npm ci --ignore-scripts --no-audit --no-fund";
+  const installIndex = deploy.indexOf(installCommand);
+  const firstActionIndex = deploy.indexOf(officialUse);
+  const wranglerVersion = packageJson.devDependencies.wrangler;
+  const lockRootVersion = packageLock.packages[""].devDependencies.wrangler;
+  const lockedWrangler = packageLock.packages["node_modules/wrangler"];
 
   assert.equal(occurrences(deploy, officialUse), 2);
-  assert.equal(occurrences(deploy, 'wranglerVersion: "4.123.0"'), 2);
+  assert.equal(occurrences(deploy, "wranglerVersion:"), 0);
+  assert.ok(installIndex >= 0, "Deploy must install the lockfile dependencies");
+  assert.ok(firstActionIndex >= 0, "Deploy must invoke the Wrangler action");
+  assert.ok(
+    installIndex < firstActionIndex,
+    "Deploy must install the lockfile-selected Wrangler before both actions",
+  );
   assert.equal(
-    occurrences(
-      deploy,
-      "apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}",
-    ),
+    occurrences(deploy, "apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}"),
     2,
   );
   assert.equal(
-    occurrences(
-      deploy,
-      "accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}",
-    ),
+    occurrences(deploy, "accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}"),
     2,
   );
 
@@ -119,11 +128,12 @@ test("both Cloudflare deploys remain on the official Wrangler action", () => {
     /workingDirectory: \.[\s\S]*command: deploy --strict --config workers\/taxaipca-motor\/wrangler\.json/u,
   );
 
-  assert.equal(packageJson.devDependencies.wrangler, "4.123.0");
-  assert.equal(
-    packageLock.packages["node_modules/wrangler"].version,
-    "4.123.0",
-  );
+  assert.match(wranglerVersion, /^4\.\d+\.\d+$/u);
+  assert.equal(lockRootVersion, wranglerVersion);
+  assert.equal(lockedWrangler.version, wranglerVersion);
+  assert.equal(installedWrangler.version, lockedWrangler.version);
+  assert.equal(lockedWrangler.dev, true);
+  assert.match(lockedWrangler.integrity, /^sha512-/u);
   assert.equal(occurrences(actionsLock, officialUse), 2);
 });
 


### PR DESCRIPTION
## Resumo

- incorpora o bump validado de Wrangler 4.124.0 e Vitest 4.1.11 do Dependabot #259;
- remove `wranglerVersion` duplicado dos dois deploys e usa a CLI já instalada pelo `npm ci`/lockfile;
- substitui versões literais por invariantes entre manifesto, lockfile e pacote instalado;
- mantém as duas cópias de `THIRDPARTY.md` idênticas e fiéis ao manifesto.

## Validação

- `npm test` (91 testes funcionais + 4 contratos)
- `npm run lint`
- `npm run biome`
- `npm run build`
- `npm run format:public:check`
- `node scripts/verify-thirdparty.mjs`
- `gh actions-lock --no-fix --json=valid,findings` (`valid: true`)
- `git diff --check`

Linear: https://linear.app/lcv-ideas-software/issue/ORAFINC-14/maintenance-usar-o-wrangler-selecionado-pelo-lockfile-e-concluir-bump

Supersedes #259.
Closes #261.