### PR TITLE
chore: update audit actions and dependency inventory

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: npm
-          wranglerVersion: 4.127.1
+          wranglerVersion: 4.128.0
           workingDirectory: .
           command: pages deploy dist --project-name=oraculo-financeiro --branch=main --commit-dirty=true
 
@@ -70,6 +70,6 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: npm
-          wranglerVersion: 4.127.1
+          wranglerVersion: 4.128.0
           workingDirectory: .
           command: deploy --strict --config workers/taxaipca-motor/wrangler.json

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -46,6 +46,6 @@ jobs:
           retention-days: 5
 
       - name: Upload Scorecard results to code scanning
-        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        uses: github/codeql-action/upload-sarif@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4.38.0
         with:
           sarif_file: results.sarif

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -33,4 +33,4 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3
+        uses: zizmorcore/zizmor-action@cc914d7f3750a2d13d75c7f184a1060aa0e9d482 # v0.6.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Changed
 
+- Atualiza as actions oficiais do CodeQL para 4.38.0 e do Zizmor para 0.6.4,
+  com SHAs completos, e alinha os dois deploys ao Wrangler 4.128.0 já declarado.
+- Atualiza as versões de `@types/node`, `globals`, `lucide-react` e `wrangler`
+  no inventário de terceiros e na cópia pública conforme o manifesto atual.
+- Alinha o cabeçalho de `lucide-react` nos avisos integrais e na cópia pública
+  à versão 1.39.0 distribuída, após confirmar que os textos de licença coincidem.
+
 - Atualiza a dependência transitiva de desenvolvimento `sharp` para 0.35.4
   pelo override nativo do npm, preservando a versão do Wrangler, as dependências
   de produção e a versão interna da aplicação.

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -312,7 +312,7 @@ SOFTWARE.
 
 ==============================================================================
 
-lucide-react 1.38.0
+lucide-react 1.39.0
 Escopo: navegador
 Licenca declarada: ISC
 Licencas adicionais preservadas no arquivo agregado: MIT

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -4,7 +4,7 @@
 |------------|--------|------------------|-------------|----------------|
 | @biomejs/biome | ^2.5.8 | MIT OR Apache-2.0 | Não | https://registry.npmjs.org/@biomejs/biome |
 | @eslint/js | ^10.0.1 | MIT | Não | https://registry.npmjs.org/@eslint/js |
-| @types/node | ^26.2.0 | MIT | Não | https://registry.npmjs.org/@types/node |
+| @types/node | ^26.4.1 | MIT | Não | https://registry.npmjs.org/@types/node |
 | @types/react | ^19.2.18 | MIT | Não | https://registry.npmjs.org/@types/react |
 | @types/react-dom | ^19.2.4 | MIT | Não | https://registry.npmjs.org/@types/react-dom |
 | @types/sanitize-html | ^2.16.1 | MIT | Não | https://registry.npmjs.org/@types/sanitize-html |
@@ -13,9 +13,9 @@
 | eslint-config-prettier | ^10.1.8 | MIT | Não | https://registry.npmjs.org/eslint-config-prettier |
 | eslint-plugin-react-hooks | ^7.1.1 | MIT | Não | https://registry.npmjs.org/eslint-plugin-react-hooks |
 | eslint-plugin-react-refresh | ^0.5.4 | MIT | Não | https://registry.npmjs.org/eslint-plugin-react-refresh |
-| globals | ^17.11.0 | MIT | Não | https://registry.npmjs.org/globals |
+| globals | ^17.12.0 | MIT | Não | https://registry.npmjs.org/globals |
 | happy-dom | ^20.11.6 | MIT | Não | https://registry.npmjs.org/happy-dom |
-| lucide-react | ^1.31.0 | ISC | Não | https://registry.npmjs.org/lucide-react |
+| lucide-react | ^1.39.0 | ISC | Não | https://registry.npmjs.org/lucide-react |
 | prettier | ^3.9.6 | MIT | Não | https://registry.npmjs.org/prettier |
 | react | ^19.2.8 | MIT | Não | https://registry.npmjs.org/react |
 | react-dom | ^19.2.8 | MIT | Não | https://registry.npmjs.org/react-dom |
@@ -24,7 +24,7 @@
 | typescript-eslint | ^8.67.0 | MIT | Não | https://registry.npmjs.org/typescript-eslint |
 | vite | ^8.2.1 | MIT | Não | https://registry.npmjs.org/vite |
 | vitest | ^4.1.10 | MIT | Não | https://registry.npmjs.org/vitest |
-| wrangler | 4.127.1 | MIT OR Apache-2.0 | Não | https://registry.npmjs.org/wrangler |
+| wrangler | 4.128.0 | MIT OR Apache-2.0 | Não | https://registry.npmjs.org/wrangler |
 
 ## Eleição de licença em expressões OR
 

--- a/public/legal/THIRD-PARTY-NOTICES.txt
+++ b/public/legal/THIRD-PARTY-NOTICES.txt
@@ -312,7 +312,7 @@ SOFTWARE.
 
 ==============================================================================
 
-lucide-react 1.38.0
+lucide-react 1.39.0
 Escopo: navegador
 Licenca declarada: ISC
 Licencas adicionais preservadas no arquivo agregado: MIT

--- a/public/legal/THIRDPARTY.md
+++ b/public/legal/THIRDPARTY.md
@@ -4,7 +4,7 @@
 |------------|--------|------------------|-------------|----------------|
 | @biomejs/biome | ^2.5.8 | MIT OR Apache-2.0 | Não | https://registry.npmjs.org/@biomejs/biome |
 | @eslint/js | ^10.0.1 | MIT | Não | https://registry.npmjs.org/@eslint/js |
-| @types/node | ^26.2.0 | MIT | Não | https://registry.npmjs.org/@types/node |
+| @types/node | ^26.4.1 | MIT | Não | https://registry.npmjs.org/@types/node |
 | @types/react | ^19.2.18 | MIT | Não | https://registry.npmjs.org/@types/react |
 | @types/react-dom | ^19.2.4 | MIT | Não | https://registry.npmjs.org/@types/react-dom |
 | @types/sanitize-html | ^2.16.1 | MIT | Não | https://registry.npmjs.org/@types/sanitize-html |
@@ -13,9 +13,9 @@
 | eslint-config-prettier | ^10.1.8 | MIT | Não | https://registry.npmjs.org/eslint-config-prettier |
 | eslint-plugin-react-hooks | ^7.1.1 | MIT | Não | https://registry.npmjs.org/eslint-plugin-react-hooks |
 | eslint-plugin-react-refresh | ^0.5.4 | MIT | Não | https://registry.npmjs.org/eslint-plugin-react-refresh |
-| globals | ^17.11.0 | MIT | Não | https://registry.npmjs.org/globals |
+| globals | ^17.12.0 | MIT | Não | https://registry.npmjs.org/globals |
 | happy-dom | ^20.11.6 | MIT | Não | https://registry.npmjs.org/happy-dom |
-| lucide-react | ^1.31.0 | ISC | Não | https://registry.npmjs.org/lucide-react |
+| lucide-react | ^1.39.0 | ISC | Não | https://registry.npmjs.org/lucide-react |
 | prettier | ^3.9.6 | MIT | Não | https://registry.npmjs.org/prettier |
 | react | ^19.2.8 | MIT | Não | https://registry.npmjs.org/react |
 | react-dom | ^19.2.8 | MIT | Não | https://registry.npmjs.org/react-dom |
@@ -24,7 +24,7 @@
 | typescript-eslint | ^8.67.0 | MIT | Não | https://registry.npmjs.org/typescript-eslint |
 | vite | ^8.2.1 | MIT | Não | https://registry.npmjs.org/vite |
 | vitest | ^4.1.10 | MIT | Não | https://registry.npmjs.org/vitest |
-| wrangler | 4.127.1 | MIT OR Apache-2.0 | Não | https://registry.npmjs.org/wrangler |
+| wrangler | 4.128.0 | MIT OR Apache-2.0 | Não | https://registry.npmjs.org/wrangler |
 
 ## Eleição de licença em expressões OR
 


### PR DESCRIPTION
O inventário e os workflows ainda usavam referências anteriores às versões oficiais verificadas e ao lockfile. Esta alteração atualiza CodeQL e zizmor-action pelos SHAs oficiais, alinha dois inputs Wrangler ao lockfile e corrige versões/cabeçalhos nas duas cópias do inventário e dos avisos, preservando os textos legais.

Validação local: 84 testes, lint, Biome, build, formatação pública e npm audit aprovados. Reproduções de divergência passaram para zero; git diff --check limpo. Commit assinado e verificado. CI e revisão no SHA deste PR serão conferidos antes da integração.

Acompanhamento: [ORAFINC-19](https://linear.app/lcv-ideas-software/issue/ORAFINC-19) · [LCV-178](https://linear.app/lcv-ideas-software/issue/LCV-178).
