### PR TITLE
chore: align legal inventory and Wrangler inputs (ORAFINC-21)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: npm
-          wranglerVersion: 4.128.0
+          wranglerVersion: 4.129.0
           workingDirectory: .
           command: pages deploy dist --project-name=oraculo-financeiro --branch=main --commit-dirty=true
 
@@ -70,6 +70,6 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: npm
-          wranglerVersion: 4.128.0
+          wranglerVersion: 4.129.0
           workingDirectory: .
           command: deploy --strict --config workers/taxaipca-motor/wrangler.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@
 ### Changed
 
 - Atualiza as actions oficiais do CodeQL para 4.38.0 e do Zizmor para 0.6.4,
-  com SHAs completos, e alinha os dois deploys ao Wrangler 4.128.0 já declarado.
-- Atualiza as versões de `@types/node`, `globals`, `lucide-react` e `wrangler`
-  no inventário de terceiros e na cópia pública conforme o manifesto atual.
+  com SHAs completos, e alinha os dois deploys ao Wrangler 4.129.0 já declarado.
+- Atualiza as versões de `@biomejs/biome`, `@types/node`, `@types/react-dom`,
+  `eslint-plugin-react-refresh`, `globals`, `happy-dom`, `lucide-react`, `vitest`
+  e `wrangler` no inventário de terceiros e na cópia pública conforme o manifesto
+  atual, incluindo Wrangler 4.129.0.
 - Alinha o cabeçalho de `lucide-react` nos avisos integrais e na cópia pública
-  à versão 1.39.0 distribuída, após confirmar que os textos de licença coincidem.
+  à versão 1.40.0 distribuída, após confirmar que os textos de licença coincidem.
 
 - Atualiza a dependência transitiva de desenvolvimento `sharp` para 0.35.4
   pelo override nativo do npm, preservando a versão do Wrangler, as dependências

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -312,7 +312,7 @@ SOFTWARE.
 
 ==============================================================================
 
-lucide-react 1.39.0
+lucide-react 1.40.0
 Escopo: navegador
 Licenca declarada: ISC
 Licencas adicionais preservadas no arquivo agregado: MIT

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -2,20 +2,20 @@
 
 | Componente | Versão | Licença Original | Modificado? | Link de Origem |
 |------------|--------|------------------|-------------|----------------|
-| @biomejs/biome | ^2.5.8 | MIT OR Apache-2.0 | Não | https://registry.npmjs.org/@biomejs/biome |
+| @biomejs/biome | ^2.5.12 | MIT OR Apache-2.0 | Não | https://registry.npmjs.org/@biomejs/biome |
 | @eslint/js | ^10.0.1 | MIT | Não | https://registry.npmjs.org/@eslint/js |
 | @types/node | ^26.4.1 | MIT | Não | https://registry.npmjs.org/@types/node |
 | @types/react | ^19.2.18 | MIT | Não | https://registry.npmjs.org/@types/react |
-| @types/react-dom | ^19.2.4 | MIT | Não | https://registry.npmjs.org/@types/react-dom |
+| @types/react-dom | ^19.2.7 | MIT | Não | https://registry.npmjs.org/@types/react-dom |
 | @types/sanitize-html | ^2.16.1 | MIT | Não | https://registry.npmjs.org/@types/sanitize-html |
 | @vitejs/plugin-react | ^6.0.5 | MIT | Não | https://registry.npmjs.org/@vitejs/plugin-react |
 | eslint | ^10.8.1 | MIT | Não | https://registry.npmjs.org/eslint |
 | eslint-config-prettier | ^10.1.8 | MIT | Não | https://registry.npmjs.org/eslint-config-prettier |
 | eslint-plugin-react-hooks | ^7.1.1 | MIT | Não | https://registry.npmjs.org/eslint-plugin-react-hooks |
-| eslint-plugin-react-refresh | ^0.5.4 | MIT | Não | https://registry.npmjs.org/eslint-plugin-react-refresh |
+| eslint-plugin-react-refresh | ^0.5.6 | MIT | Não | https://registry.npmjs.org/eslint-plugin-react-refresh |
 | globals | ^17.12.0 | MIT | Não | https://registry.npmjs.org/globals |
-| happy-dom | ^20.11.6 | MIT | Não | https://registry.npmjs.org/happy-dom |
-| lucide-react | ^1.39.0 | ISC | Não | https://registry.npmjs.org/lucide-react |
+| happy-dom | ^20.14.0 | MIT | Não | https://registry.npmjs.org/happy-dom |
+| lucide-react | ^1.40.0 | ISC | Não | https://registry.npmjs.org/lucide-react |
 | prettier | ^3.9.6 | MIT | Não | https://registry.npmjs.org/prettier |
 | react | ^19.2.8 | MIT | Não | https://registry.npmjs.org/react |
 | react-dom | ^19.2.8 | MIT | Não | https://registry.npmjs.org/react-dom |
@@ -23,8 +23,8 @@
 | typescript | ~6.0.3 | Apache-2.0 | Não | https://registry.npmjs.org/typescript |
 | typescript-eslint | ^8.67.0 | MIT | Não | https://registry.npmjs.org/typescript-eslint |
 | vite | ^8.2.1 | MIT | Não | https://registry.npmjs.org/vite |
-| vitest | ^4.1.10 | MIT | Não | https://registry.npmjs.org/vitest |
-| wrangler | 4.128.0 | MIT OR Apache-2.0 | Não | https://registry.npmjs.org/wrangler |
+| vitest | ^5.0.0 | MIT | Não | https://registry.npmjs.org/vitest |
+| wrangler | 4.129.0 | MIT OR Apache-2.0 | Não | https://registry.npmjs.org/wrangler |
 
 ## Eleição de licença em expressões OR
 

--- a/public/legal/THIRD-PARTY-NOTICES.txt
+++ b/public/legal/THIRD-PARTY-NOTICES.txt
@@ -312,7 +312,7 @@ SOFTWARE.
 
 ==============================================================================
 
-lucide-react 1.39.0
+lucide-react 1.40.0
 Escopo: navegador
 Licenca declarada: ISC
 Licencas adicionais preservadas no arquivo agregado: MIT

--- a/public/legal/THIRDPARTY.md
+++ b/public/legal/THIRDPARTY.md
@@ -2,20 +2,20 @@
 
 | Componente | Versão | Licença Original | Modificado? | Link de Origem |
 |------------|--------|------------------|-------------|----------------|
-| @biomejs/biome | ^2.5.8 | MIT OR Apache-2.0 | Não | https://registry.npmjs.org/@biomejs/biome |
+| @biomejs/biome | ^2.5.12 | MIT OR Apache-2.0 | Não | https://registry.npmjs.org/@biomejs/biome |
 | @eslint/js | ^10.0.1 | MIT | Não | https://registry.npmjs.org/@eslint/js |
 | @types/node | ^26.4.1 | MIT | Não | https://registry.npmjs.org/@types/node |
 | @types/react | ^19.2.18 | MIT | Não | https://registry.npmjs.org/@types/react |
-| @types/react-dom | ^19.2.4 | MIT | Não | https://registry.npmjs.org/@types/react-dom |
+| @types/react-dom | ^19.2.7 | MIT | Não | https://registry.npmjs.org/@types/react-dom |
 | @types/sanitize-html | ^2.16.1 | MIT | Não | https://registry.npmjs.org/@types/sanitize-html |
 | @vitejs/plugin-react | ^6.0.5 | MIT | Não | https://registry.npmjs.org/@vitejs/plugin-react |
 | eslint | ^10.8.1 | MIT | Não | https://registry.npmjs.org/eslint |
 | eslint-config-prettier | ^10.1.8 | MIT | Não | https://registry.npmjs.org/eslint-config-prettier |
 | eslint-plugin-react-hooks | ^7.1.1 | MIT | Não | https://registry.npmjs.org/eslint-plugin-react-hooks |
-| eslint-plugin-react-refresh | ^0.5.4 | MIT | Não | https://registry.npmjs.org/eslint-plugin-react-refresh |
+| eslint-plugin-react-refresh | ^0.5.6 | MIT | Não | https://registry.npmjs.org/eslint-plugin-react-refresh |
 | globals | ^17.12.0 | MIT | Não | https://registry.npmjs.org/globals |
-| happy-dom | ^20.11.6 | MIT | Não | https://registry.npmjs.org/happy-dom |
-| lucide-react | ^1.39.0 | ISC | Não | https://registry.npmjs.org/lucide-react |
+| happy-dom | ^20.14.0 | MIT | Não | https://registry.npmjs.org/happy-dom |
+| lucide-react | ^1.40.0 | ISC | Não | https://registry.npmjs.org/lucide-react |
 | prettier | ^3.9.6 | MIT | Não | https://registry.npmjs.org/prettier |
 | react | ^19.2.8 | MIT | Não | https://registry.npmjs.org/react |
 | react-dom | ^19.2.8 | MIT | Não | https://registry.npmjs.org/react-dom |
@@ -23,8 +23,8 @@
 | typescript | ~6.0.3 | Apache-2.0 | Não | https://registry.npmjs.org/typescript |
 | typescript-eslint | ^8.67.0 | MIT | Não | https://registry.npmjs.org/typescript-eslint |
 | vite | ^8.2.1 | MIT | Não | https://registry.npmjs.org/vite |
-| vitest | ^4.1.10 | MIT | Não | https://registry.npmjs.org/vitest |
-| wrangler | 4.128.0 | MIT OR Apache-2.0 | Não | https://registry.npmjs.org/wrangler |
+| vitest | ^5.0.0 | MIT | Não | https://registry.npmjs.org/vitest |
+| wrangler | 4.129.0 | MIT OR Apache-2.0 | Não | https://registry.npmjs.org/wrangler |
 
 ## Eleição de licença em expressões OR
 


### PR DESCRIPTION
Os inventários legais ainda registravam sete versões anteriores em cada cópia; os avisos indicavam lucide-react 1.39.0, e os dois deploys selecionavam Wrangler 4.128.0 apesar do manifesto e lockfile 4.129.0. Este PR sincroniza as versões documentadas, corrige os cabeçalhos para lucide-react 1.40.0, alinha ambos os inputs Wrangler e atualiza Unreleased.

O LICENSE integral do artefato lucide-react 1.40.0, validado pelo SRI do lockfile, coincide com o texto já preservado nos avisos. As duas cópias legais permanecem iguais; manifesto, lockfile, código do produto e textos de licença permanecem iguais aos da base.

Validação: 84 testes em 8 arquivos, ESLint, Biome, build e formatação pública aprovados; reprodução dos dois inputs Wrangler sem divergências; diff restrito aos seis arquivos previstos.

Closes #308
Fixes ORAFINC-21
Auditoria: [LCV-181](https://linear.app/lcv-ideas-software/issue/LCV-181).
